### PR TITLE
Execute S3 copy operations concurrently

### DIFF
--- a/3-etl/emr-etl-runner/config/config.yml
+++ b/3-etl/emr-etl-runner/config/config.yml
@@ -7,6 +7,7 @@
     :assets: ADD HERE
     :serde: ADD HERE
     :in: ADD HERE
+    :processing: ADD HERE
     :out: ADD HERE
     :archive: ADD HERE
 :emr:

--- a/3-etl/emr-etl-runner/lib/snowplow-emr-etl-runner/version.rb
+++ b/3-etl/emr-etl-runner/lib/snowplow-emr-etl-runner/version.rb
@@ -2,7 +2,7 @@ module SnowPlow
   module EmrEtlRunner
   	SCRIPT_NAME = "snowplow-emr-etl-runner"
     VERSION = "0.0.2"
-    HADOOP_VERSION = "2.2.1"
     HIVE_SERDE_VERSION = "0.4.8"
+    HADOOP_VERSION = "1.0.3"
   end
 end


### PR DESCRIPTION
The S3 copy operations are a big bottleneck

This change allows us to execute the S3 copy operations concurrently using Ruby threads.

I've also refactored move_files into it's own function and created a simple class to handle S3 locations
