### PR TITLE
Adds an argument to process a bucket directly

### DIFF
--- a/3-etl/emr-etl-runner/bin/snowplow-emr-etl-runner
+++ b/3-etl/emr-etl-runner/bin/snowplow-emr-etl-runner
@@ -32,16 +32,18 @@ require 'snowplow-emr-etl-runner'; runner = SnowPlow::EmrEtlRunner
 begin
   config = runner::Config.get_config()
 
-  if config[:skip] == :none
+  unless config[:skip].include?('staging')
     runner::S3Tasks.stage_logs_for_emr(config)
   end
 
-  unless config[:skip] == :emr
+  unless config[:skip].include?('emr')
     job = runner::EmrJob.new(config)
     job.run()
   end
 
-  runner::S3Tasks.archive_logs(config)
+  unless config[:skip].include?('archive')
+    runner::S3Tasks.archive_logs(config)
+  end
 
 # Catch any SnowPlow error
 rescue runner::Error => e


### PR DESCRIPTION
Also allows the skip option to have multiple arguments.

Hey @alexanderdean,

We're now using aggregated hourly files, so we just want to be able to point the ETL runner at a bucket that should be processed - without staging and archiving.

The name of the bucket and prefix varies (by date), so I've put the bucket name as an option on the command line to allow it to be specified.

What do you think?
