### PR TITLE
Fix for setting of cookieSecure in tracker

### DIFF
--- a/1-trackers/javascript-tracker/js/src/tracker.js
+++ b/1-trackers/javascript-tracker/js/src/tracker.js
@@ -141,7 +141,7 @@ SnowPlow.Tracker = function Tracker(argmap) {
 		configAttachUserId = true, 
 
 		// Should cookies have the secure flag set
-		cookieSecure = SnowPlow.documentAlias.location.protocol === 'https',
+		cookieSecure = SnowPlow.documentAlias.location.protocol === 'https:',
 
 		// Browser language (or Windows language for IE). Imperfect but CloudFront doesn't log the Accept-Language header
 		browserLanguage = SnowPlow.navigatorAlias.userLanguage || SnowPlow.navigatorAlias.language,


### PR DESCRIPTION
Looking at the cookies I noticed that they are not set to be secure when the page is served over SSL.

Looking in tracker.js I spotted this:

```
    cookieSecure = SnowPlow.documentAlias.location.protocol === 'https',
```

This should read 

```
    cookieSecure = SnowPlow.documentAlias.location.protocol === 'https:',
```

I couldn't find any tests so I'm having a look at writing some with Jasmine (I'll do this separately from this change.)
