### PR TITLE
Process archived logs in datestamped directories

### DIFF
--- a/3-enrich/emr-etl-runner/config/config.yml.sample
+++ b/3-enrich/emr-etl-runner/config/config.yml.sample
@@ -28,7 +28,7 @@
     :task_instance_bid: 0.015 # In USD. Adjust bid, or leave blank for non-spot-priced (i.e. on-demand) task instances
 :etl:
   :job_name: SnowPlow ETL # Give your job a name
-  :hadoop_etl_version: 0.4.0 # Version of the Hadoop Enrichment process
+  :hadoop_etl_version: 0.5.0 # Version of the Hadoop Enrichment process
   :collector_format: cloudfront # Or 'clj-tomcat' for the Clojure Collector
   :continue_on_unexpected_error: false # You can switch to 'true' (and set :out_errors: above) if you really don't want the ETL throwing exceptions
 :enrichments:

--- a/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/config.rb
+++ b/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/config.rb
@@ -50,6 +50,11 @@ module SnowPlow
           config[:s3][:buckets][:processing] = options[:processbucket]
         end
 
+        unless options[:processarchive].nil?
+          config[:s3][:buckets][:processing] = options[:processarchive]
+          config[:s3][:archived] = true
+        end
+
         # Add trailing slashes if needed to the non-nil buckets
         config[:s3][:buckets].reject{|k,v| v.nil?}.update(config[:s3][:buckets]){|k,v| Sluice::Storage::trail_slash(v)}
 
@@ -66,7 +71,7 @@ module SnowPlow
         config[:emr][:jobflow].delete_if {|k, _| k.to_s.start_with?("core_") }
 
         # Validate the collector format
-        unless @@collector_formats.include?(config[:etl][:collector_format]) 
+        unless @@collector_formats.include?(config[:etl][:collector_format])
           raise ConfigError, "collector_format '%s' not supported" % config[:etl][:collector_format]
         end
 
@@ -136,8 +141,12 @@ module SnowPlow
           opts.on('-s', '--start YYYY-MM-DD', 'optional start date *') { |config| options[:start] = config }
           opts.on('-e', '--end YYYY-MM-DD', 'optional end date *') { |config| options[:end] = config }
           opts.on('-s', '--skip staging,emr,archive', Array, 'skip work step(s)') { |config| options[:skip] = config }
-          opts.on('-b', '--process-bucket BUCKET', 'run emr only on specified bucket. Implies --skip staging,archive') { |config| 
+          opts.on('-b', '--process-bucket BUCKET', 'run emr only on specified bucket. Implies --skip staging,archive') { |config|
             options[:processbucket] = config
+            options[:skip] = %w(staging archive)
+          }
+          opts.on('-a', '--process-archive BUCKET', 'run emr only on specified archive bucket. Requires --start, implies --skip staging,archive') { |config|
+            options[:processarchive] = config
             options[:skip] = %w(staging archive)
           }
 
@@ -177,6 +186,11 @@ module SnowPlow
         # Check the config file exists
         unless File.file?(options[:config])
           raise ConfigError, "Configuration file '#{options[:config]}' does not exist, or is not a file."
+        end
+
+        # Check if archived directories are processed, start is set
+        if options[:processarchive] and options[:start].nil?
+          raise ConfigError, "Missing option: start must be set when processing archive bucket."
         end
 
         # Finally check that start is before end, if both set

--- a/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/config.rb
+++ b/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/config.rb
@@ -51,7 +51,7 @@ module SnowPlow
         end
 
         unless options[:processarchive].nil?
-          config[:s3][:buckets][:processing] = options[:processarchive]
+          config[:s3][:buckets][:processing] = config[:s3][:buckets][:archive]
           config[:s3][:archived] = true
         end
 
@@ -145,8 +145,8 @@ module SnowPlow
             options[:processbucket] = config
             options[:skip] = %w(staging archive)
           }
-          opts.on('-a', '--process-archive BUCKET', 'run emr only on specified archive bucket. Requires --start, implies --skip staging,archive') { |config|
-            options[:processarchive] = config
+          opts.on('-a', '--process-archive', 'run emr only on archive bucket. Requires --start, implies --skip staging,archive') {
+            options[:processarchive] = true
             options[:skip] = %w(staging archive)
           }
 

--- a/3-enrich/scala-hadoop-bad-rows/.gitignore
+++ b/3-enrich/scala-hadoop-bad-rows/.gitignore
@@ -1,0 +1,13 @@
+*.class
+*.log
+
+# ide specific
+.idea*
+
+# sbt specific
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/

--- a/3-enrich/scala-hadoop-bad-rows/.travis.yml
+++ b/3-enrich/scala-hadoop-bad-rows/.travis.yml
@@ -1,0 +1,7 @@
+language: scala
+scala:
+   - 2.10.4
+jdk:
+  - oraclejdk7
+  - openjdk6
+  - openjdk7

--- a/3-enrich/scala-hadoop-bad-rows/LICENSE-2.0.txt
+++ b/3-enrich/scala-hadoop-bad-rows/LICENSE-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/3-enrich/scala-hadoop-bad-rows/README.md
+++ b/3-enrich/scala-hadoop-bad-rows/README.md
@@ -1,12 +1,12 @@
-# Scalding Example Project [![Build Status](https://travis-ci.org/snowplow/scalding-example-project.png)](https://travis-ci.org/snowplow/scalding-example-project)
+# Snowplow Hadoop Bad Rows
 
 ## Introduction
 
-To come.
+Use this Scalding job to extract raw Snowplow events from your Snowplow bad rows JSONs, ready for reprocessing.
 
-### Run
+## Usage
 
-You are ready to run this job using the [Amazon Ruby EMR client] [emr-client]:
+Run this job using the [Amazon Ruby EMR client] [emr-client]:
 
     $ elastic-mapreduce --create --name "Extract raw events from Snowplow bad row JSONs" \
       --instance-type m1.xlarge --instance-count 3 \
@@ -16,26 +16,11 @@ You are ready to run this job using the [Amazon Ruby EMR client] [emr-client]:
       --arg --input --arg s3n://{{PATH_TO_YOUR_FIXABLE_BAD_ROWS}} \
       --arg --output --arg s3n://{{PATH_WILL_BE_STAGING_FOR_EMRETLRUNNER}}
 
-Replace `{{JAR_BUCKET}}`, `{{IN_BUCKET}}` and `{{OUT_BUCKET}}` with the appropriate paths.
-
-## Next steps
-
-Fork this project and adapt it into your own custom Scalding job.
-
-To invoke/schedule your Scalding job on EMR, check out:
-
-* [Spark Plug] [spark-plug] for Scala
-* [Elasticity] [elasticity] for Ruby
-* [Boto] [boto] for Python
-* [Lemur] [lemur] for Clojure
-
-## Roadmap
-
-Nothing planned currently.
+Replace the `{{...}}` placeholders above with the appropriate paths.
 
 ## Copyright and license
 
-Copyright 2012-2014 Snowplow Analytics Ltd, with significant portions copyright 2012 Twitter, Inc.
+Copyright 2014 Snowplow Analytics Ltd, with significant portions copyright 2012 Twitter, Inc.
 
 Licensed under the [Apache License, Version 2.0] [license] (the "License");
 you may not use this software except in compliance with the License.

--- a/3-enrich/scala-hadoop-bad-rows/README.md
+++ b/3-enrich/scala-hadoop-bad-rows/README.md
@@ -1,0 +1,61 @@
+# Scalding Example Project [![Build Status](https://travis-ci.org/snowplow/scalding-example-project.png)](https://travis-ci.org/snowplow/scalding-example-project)
+
+## Introduction
+
+To come.
+
+### Run
+
+You are ready to run this job using the [Amazon Ruby EMR client] [emr-client]:
+
+    $ elastic-mapreduce --create --name "Extract raw events from Snowplow bad row JSONs" \
+      --instance-type m1.xlarge --instance-count 3 \
+      --jar s3://snowplow-hosted-assets/3-enrich/scala-bad-rows/snowplow-bad-rows-0.1.0.jar \
+      --arg com.snowplowanalytics.hadoop.scalding.SnowplowBadRowsJob \
+      --arg --hdfs \
+      --arg --input --arg s3n://{{PATH_TO_YOUR_FIXABLE_BAD_ROWS}} \
+      --arg --output --arg s3n://{{PATH_WILL_BE_STAGING_FOR_EMRETLRUNNER}}
+
+Replace `{{JAR_BUCKET}}`, `{{IN_BUCKET}}` and `{{OUT_BUCKET}}` with the appropriate paths.
+
+## Next steps
+
+Fork this project and adapt it into your own custom Scalding job.
+
+To invoke/schedule your Scalding job on EMR, check out:
+
+* [Spark Plug] [spark-plug] for Scala
+* [Elasticity] [elasticity] for Ruby
+* [Boto] [boto] for Python
+* [Lemur] [lemur] for Clojure
+
+## Roadmap
+
+Nothing planned currently.
+
+## Copyright and license
+
+Copyright 2012-2014 Snowplow Analytics Ltd, with significant portions copyright 2012 Twitter, Inc.
+
+Licensed under the [Apache License, Version 2.0] [license] (the "License");
+you may not use this software except in compliance with the License.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+[wordcount]: https://github.com/twitter/scalding/blob/master/README.md
+[scalding]: https://github.com/twitter/scalding/
+[snowplow]: http://snowplowanalytics.com
+[snowplow-hadoop-enrich]: https://github.com/snowplow/snowplow/tree/master/3-enrich/scala-hadoop-enrich
+[spark-example-project]: https://github.com/snowplow/spark-example-project
+[emr]: http://aws.amazon.com/elasticmapreduce/
+[hello-txt]: https://github.com/snowplow/scalding-example-project/raw/master/data/hello.txt
+[emr-client]: http://aws.amazon.com/developertools/2264
+[elasticity]: https://github.com/rslifka/elasticity
+[spark-plug]: https://github.com/ogrodnek/spark-plug
+[lemur]: https://github.com/TheClimateCorporation/lemur
+[boto]: http://boto.readthedocs.org/en/latest/ref/emr.html
+[license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/3-enrich/scala-hadoop-bad-rows/README.md
+++ b/3-enrich/scala-hadoop-bad-rows/README.md
@@ -16,7 +16,7 @@ Run this job using the [Amazon Ruby EMR client] [emr-client]:
       --arg --input --arg s3n://{{PATH_TO_YOUR_FIXABLE_BAD_ROWS}} \
       --arg --output --arg s3n://{{PATH_WILL_BE_STAGING_FOR_EMRETLRUNNER}}
 
-Replace the `{{...}}` placeholders above with the appropriate paths.
+Replace the `{{...}}` placeholders above with the appropriate bucket paths.
 
 ## Copyright and license
 

--- a/3-enrich/scala-hadoop-bad-rows/project/BuildSettings.scala
+++ b/3-enrich/scala-hadoop-bad-rows/project/BuildSettings.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2012 SnowPlow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+import sbt._
+import Keys._
+
+object BuildSettings {
+
+  // Basic settings for our app
+  lazy val basicSettings = Seq[Setting[_]](
+    organization  := "com.snowplowanalytics",
+    version       := "0.1.0",
+    description   := "Extracts original Snowplow raw events from bad rows JSONs",
+    scalaVersion  := "2.10.4",
+    scalacOptions := Seq("-deprecation", "-encoding", "utf8"),
+    resolvers     ++= Dependencies.resolutionRepos
+  )
+
+  // sbt-assembly settings for building a fat jar
+  import sbtassembly.Plugin._
+  import AssemblyKeys._
+  lazy val sbtAssemblySettings = assemblySettings ++ Seq(
+
+    // Slightly cleaner jar name
+    jarName in assembly := { name.value + "-" + version.value + ".jar" },
+    
+    // Drop these jars
+    excludedJars in assembly <<= (fullClasspath in assembly) map { cp =>
+      val excludes = Set(
+        "jsp-api-2.1-6.1.14.jar",
+        "jsp-2.1-6.1.14.jar",
+        "jasper-compiler-5.5.12.jar",
+        "minlog-1.2.jar", // Otherwise causes conflicts with Kyro (which bundles it)
+        "janino-2.5.16.jar", // Janino includes a broken signature, and is not needed anyway
+        "commons-beanutils-core-1.8.0.jar", // Clash with each other and with commons-collections
+        "commons-beanutils-1.7.0.jar",      // "
+        "hadoop-core-1.1.2.jar", // Provided by Amazon EMR. Delete this line if you're not on EMR
+        "hadoop-tools-1.1.2.jar" // "
+      ) 
+      cp filter { jar => excludes(jar.data.getName) }
+    },
+    
+    mergeStrategy in assembly <<= (mergeStrategy in assembly) {
+      (old) => {
+        case "project.clj" => MergeStrategy.discard // Leiningen build files
+        case x => old(x)
+      }
+    }
+  )
+
+  lazy val buildSettings = basicSettings ++ sbtAssemblySettings
+}

--- a/3-enrich/scala-hadoop-bad-rows/project/Dependencies.scala
+++ b/3-enrich/scala-hadoop-bad-rows/project/Dependencies.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2012 SnowPlow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+import sbt._
+
+object Dependencies {
+  val resolutionRepos = Seq(
+    "ScalaTools snapshots at Sonatype" at "https://oss.sonatype.org/content/repositories/snapshots/",
+    "Concurrent Maven Repo" at "http://conjars.org/repo" // For Scalding, Cascading etc
+  )
+
+  object V {
+    val scalding  = "0.9.1"
+    val hadoop    = "1.1.2"
+    val specs2    = "2.3.11"
+    // Add versions for your additional libraries here...
+  }
+
+  object Libraries {
+    val scaldingCore = "com.twitter"                %%  "scalding-core"       % V.scalding
+    val scaldingJson = "com.twitter"                %%  "scalding-json"       % V.scalding
+    val hadoopCore   = "org.apache.hadoop"          %   "hadoop-core"         % V.hadoop       % "provided"
+    // Add additional libraries from mvnrepository.com (SBT syntax) here...
+
+    // Scala (test only)
+    val specs2       = "org.specs2"                 %% "specs2"               % V.specs2       % "test"
+  }
+}

--- a/3-enrich/scala-hadoop-bad-rows/project/SnowplowBadRowsBuild.scala
+++ b/3-enrich/scala-hadoop-bad-rows/project/SnowplowBadRowsBuild.scala
@@ -1,0 +1,38 @@
+/* 
+ * Copyright (c) 2012 SnowPlow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+import sbt._
+import Keys._
+
+object SnowplowBadRowsBuild extends Build {
+
+  import Dependencies._
+  import BuildSettings._
+
+  // Configure prompt to show current project
+  override lazy val settings = super.settings :+ {
+    shellPrompt := { s => Project.extract(s).currentProject.id + " > " }
+  }
+
+  // Define our project, with basic project information and library dependencies
+  lazy val project = Project("snowplow-bad-rows", file("."))
+    .settings(buildSettings: _*)
+    .settings(
+      libraryDependencies ++= Seq(
+        Libraries.scaldingCore,
+        Libraries.scaldingJson,
+        Libraries.hadoopCore,
+        Libraries.specs2
+        // Add your additional libraries here (comma-separated)...
+      )
+    )
+}

--- a/3-enrich/scala-hadoop-bad-rows/project/build.properties
+++ b/3-enrich/scala-hadoop-bad-rows/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.2

--- a/3-enrich/scala-hadoop-bad-rows/project/plugins.sbt
+++ b/3-enrich/scala-hadoop-bad-rows/project/plugins.sbt
@@ -1,0 +1,3 @@
+resolvers += Resolver.url("plugins-artifactory", url("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")

--- a/3-enrich/scala-hadoop-bad-rows/src/main/scala/com/snowplowanalytics/hadoop/scalding/JobRunner.scala
+++ b/3-enrich/scala-hadoop-bad-rows/src/main/scala/com/snowplowanalytics/hadoop/scalding/JobRunner.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2012 SnowPlow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.hadoop.scalding
+
+// Hadoop
+import org.apache.hadoop
+
+// Scalding
+import com.twitter.scalding.Tool
+
+/**
+ * Entrypoint for Hadoop to kick off the job.
+ *
+ * Borrowed from com.twitter.scalding.Tool
+ */
+object JobRunner {
+  def main(args : Array[String]) {
+    hadoop.util.ToolRunner.run(new hadoop.conf.Configuration, new Tool, args);
+  }
+}

--- a/3-enrich/scala-hadoop-bad-rows/src/main/scala/com/snowplowanalytics/hadoop/scalding/SnowplowBadRowsJob.scala
+++ b/3-enrich/scala-hadoop-bad-rows/src/main/scala/com/snowplowanalytics/hadoop/scalding/SnowplowBadRowsJob.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2012 Twitter, Inc.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.hadoop.scalding
+
+// Scalding
+import com.twitter.scalding.{JsonLine => StandardJsonLine, _}
+
+// Cascading
+import cascading.tuple.Fields
+import cascading.tap.SinkMode
+
+object JsonLine {
+  def apply(p: String, fields: Fields = Fields.ALL) = new JsonLine(p, fields)
+}
+class JsonLine(p: String, fields: Fields) extends StandardJsonLine(p, fields, SinkMode.REPLACE) {
+  // We want to test the actual tranformation here.
+  override val transformInTest = true
+}
+
+class SnowplowBadRowsJob(args : Args) extends Job(args) {
+  JsonLine(args("input"), ('line, 'errors)).read
+  	.project('line)
+  	.write(Tsv(args("output")))
+}

--- a/3-enrich/scala-hadoop-bad-rows/src/test/scala/com/snowplowanalytics/hadoop/scalding/SnowplowBadRowsJobSpec.scala
+++ b/3-enrich/scala-hadoop-bad-rows/src/test/scala/com/snowplowanalytics/hadoop/scalding/SnowplowBadRowsJobSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2012 Twitter, Inc.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.hadoop.scalding
+
+// Specs2
+import org.specs2.mutable.Specification
+
+// Scalding
+import com.twitter.scalding.{JsonLine => StandardJsonLine, _}
+
+// Cascading
+import cascading.tuple.Fields
+import cascading.tap.SinkMode
+
+object JsonLine {
+  def apply(p: String, fields: Fields = Fields.ALL) = new JsonLine(p, fields)
+}
+class JsonLine(p: String, fields: Fields) extends StandardJsonLine(p, fields, SinkMode.REPLACE) {
+  // We want to test the actual tranformation here.
+  override val transformInTest = true
+}
+
+class SnowplowBadRowsJobSpec extends Specification {
+  import Dsl._
+
+  "A SnowplowBadRows job" should {
+    JobTest("com.snowplowanalytics.hadoop.scalding.SnowplowBadRowsJob")
+      .arg("input", "inputFile")
+      .arg("output", "outputFile")
+      .source(JsonLine("inputFile", ('line, 'errors)), List((0, """{"line":"2014-04-28\t18:13:40\tJFK1\t831\t76.9.199.178\tGET\td3v6ndkyapxc2w.cloudfront.net\t/i\t200\thttp://snowplowanalytics.com/analytics/customer-analytics/cohort-analysis.html\tMozilla/5.0%2520(Macintosh;%2520Intel%2520Mac%2520OS%2520X%252010_9_2)%2520AppleWebKit/537.36%2520(KHTML,%2520like%2520Gecko)%2520Chrome/34.0.1847.131%2520Safari/537.36\te=pp&page=Cohort%2520Analysis&pp_mix=0&pp_max=0&pp_miy=1999&pp_may=1999&cx=eyJwYWdlIjp7InVybCI6ImFuYWx5dGljcyJ9fQ&dtm=1398708819267&tid=319357&vp=1436x783&ds=1436x6689&vid=4&duid=d91cd3ae94725999&p=web&tv=2.0.0&fp=985410387&aid=snowplowweb&lang=en-US&cs=UTF-8&tz=America%252FNew_York&tna=cloudfront&evn=com.snowplowanalytics&refr=http%253A%252F%252Fsnowplowanalytics.com%252Fanalytics%252Fcustomer-analytics%252Fattribution.html&f_pdf=1&f_qt=1&f_realp=0&f_wma=0&f_dir=0&f_fla=1&f_java=1&f_gears=0&f_ag=1&res=1920x1080&cd=24&cookie=1&url=http%253A%252F%252Fsnowplowanalytics.com%252Fanalytics%252Fcustomer-analytics%252Fcohort-analysis.html\t-\tHit\t1x0ytHOrKiCpOY9JW7UmBUm7_P1LNVgzZexm42vCShxJcUlfp8EMOw==\td3v6ndkyapxc2w.cloudfront.net\thttp\t1014\t0.001","errors":["Line does not match CloudFront header or data row formats"]}\n""")))
+      .sink[String](Tsv("outputFile")) { buf =>
+        "just extract the line" in {
+          buf.size must_== 1
+          buf.head must be_==("2014-04-28\t18:13:40\tJFK1\t831\t76.9.199.178\tGET\td3v6ndkyapxc2w.cloudfront.net\t/i\t200\thttp://snowplowanalytics.com/analytics/customer-analytics/cohort-analysis.html\tMozilla/5.0%2520(Macintosh;%2520Intel%2520Mac%2520OS%2520X%252010_9_2)%2520AppleWebKit/537.36%2520(KHTML,%2520like%2520Gecko)%2520Chrome/34.0.1847.131%2520Safari/537.36\te=pp&page=Cohort%2520Analysis&pp_mix=0&pp_max=0&pp_miy=1999&pp_may=1999&cx=eyJwYWdlIjp7InVybCI6ImFuYWx5dGljcyJ9fQ&dtm=1398708819267&tid=319357&vp=1436x783&ds=1436x6689&vid=4&duid=d91cd3ae94725999&p=web&tv=2.0.0&fp=985410387&aid=snowplowweb&lang=en-US&cs=UTF-8&tz=America%252FNew_York&tna=cloudfront&evn=com.snowplowanalytics&refr=http%253A%252F%252Fsnowplowanalytics.com%252Fanalytics%252Fcustomer-analytics%252Fattribution.html&f_pdf=1&f_qt=1&f_realp=0&f_wma=0&f_dir=0&f_fla=1&f_java=1&f_gears=0&f_ag=1&res=1920x1080&cd=24&cookie=1&url=http%253A%252F%252Fsnowplowanalytics.com%252Fanalytics%252Fcustomer-analytics%252Fcohort-analysis.html\t-\tHit\t1x0ytHOrKiCpOY9JW7UmBUm7_P1LNVgzZexm42vCShxJcUlfp8EMOw==\td3v6ndkyapxc2w.cloudfront.net\thttp\t1014\t0.001")
+        }
+      }
+      .run
+      .finish
+  }
+}

--- a/4-storage/hive-storage/hiveql/table-def.q
+++ b/4-storage/hive-storage/hiveql/table-def.q
@@ -13,7 +13,7 @@
 -- URL:         -
 --
 -- Authors:     Yali Sassoon, Alex Dean
--- Copyright:   Copyright (c) 2013 Snowplow Analytics Ltd
+-- Copyright:   Copyright (c) 2013-2014 Snowplow Analytics Ltd
 -- License:     Apache License Version 2.0
 
 CREATE EXTERNAL TABLE IF NOT EXISTS `events` (

--- a/4-storage/hive-storage/hiveql/table-def.q
+++ b/4-storage/hive-storage/hiveql/table-def.q
@@ -25,6 +25,7 @@ event string,
 event_vendor string,
 event_id string,
 txn_id int,
+name_tracker string,               -- Added in 0.1.0
 v_tracker string,
 v_collector string,
 v_etl string,

--- a/4-storage/hive-storage/hiveql/table-def.q
+++ b/4-storage/hive-storage/hiveql/table-def.q
@@ -64,11 +64,14 @@ mkt_source string,
 mkt_term string,
 mkt_content string,
 mkt_campaign string,
+contexts string,                   -- Added in 0.1.0
 se_category string,
 se_action string,
 se_label string,
 se_property string,
 se_value double,
+ue_name string,                    -- Added in 0.1.0
+ue_properties string,              -- Added in 0.1.0
 tr_orderid string,
 tr_affiliation string,
 tr_total double,

--- a/4-storage/hive-storage/hiveql/table-def.q
+++ b/4-storage/hive-storage/hiveql/table-def.q
@@ -9,10 +9,10 @@
 -- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 -- See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 --
--- Version:     0.0.1
+-- Version:     0.1.0
 -- URL:         -
 --
--- Authors:     Yali Sassoon
+-- Authors:     Yali Sassoon, Alex Dean
 -- Copyright:   Copyright (c) 2013 Snowplow Analytics Ltd
 -- License:     Apache License Version 2.0
 

--- a/4-storage/hive-storage/hiveql/table-def.q
+++ b/4-storage/hive-storage/hiveql/table-def.q
@@ -41,7 +41,9 @@ geo_city string,
 geo_zipcode string,
 geo_latitude double,
 geo_longitude double,
+page_url string,                   -- Added in 0.1.0
 page_title string,
+page_referrer string,              -- Added in 0.1.0
 page_urlscheme string,
 page_urlhost string,
 page_urlport int, 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-Version 0.9.2 (2014-04-29)
+Version 0.9.2 (2014-04-30)
 --------------------------
 Scala Hadoop Enrich: bumped to 0.5.0
 Scala Hadoop Enrich: bumped to Scala Common Enrich 0.3.0 (#699)
@@ -7,6 +7,11 @@ Scala Hadoop Enrich: bumped to using using sbt-assembly 0.11.2 (#704)
 Scala Common Enrich: bumped to 0.4.0
 Scala Common Enrich: upgraded to support new and future CloudFront file formats (#698)
 Scala Common Enrich: bumped SBT to 0.13.2 (#703)
+Scala Hadoop Bad Rows: added. Version 0.1.0
+Hive Storage: bumped table-def.q to 0.1.0
+Hive Storage: added new unstructured fields to Hive table definition (#TODO)
+Hive Storage: added raw page_url and page_referrer into Hive table (#TODO)
+Hive Storage: added name_tracker field to Hive table (#TODO)
 
 Version 0.9.1 (2014-04-11)
 --------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,9 +9,9 @@ Scala Common Enrich: upgraded to support new and future CloudFront file formats 
 Scala Common Enrich: bumped SBT to 0.13.2 (#703)
 Scala Hadoop Bad Rows: added. Version 0.1.0
 Hive Storage: bumped table-def.q to 0.1.0
-Hive Storage: added new unstructured fields to Hive table definition (#TODO)
-Hive Storage: added raw page_url and page_referrer into Hive table (#TODO)
-Hive Storage: added name_tracker field to Hive table (#TODO)
+Hive Storage: added new unstructured fields to Hive table definition (#709)
+Hive Storage: added raw page_url and page_referrer into Hive table (#710)
+Hive Storage: added name_tracker field to Hive table (#711)
 
 Version 0.9.1 (2014-04-11)
 --------------------------


### PR DESCRIPTION
A new `--process-archive` option of emr-etl-runner allows to process each datestamped directory under the archive bucket, specified by a required `--start` and an optional `--end` argument (if `--end` is omitted, the current day is used).

It does so by creating separate filecrush steps for each datestamped directory without having to move logfiles to the processing bucket. This saves hundreds of thousands of S3 requests and even more time.

If a datestamped directory between the start and end date is missing, the job flow will fail at that particular step so it's by no means foolproof.