### PR TITLE
Escaping "\" in postgres event fields

### DIFF
--- a/4-storage/storage-loader/lib/snowplow-storage-loader/postgres_loader.rb
+++ b/4-storage/storage-loader/lib/snowplow-storage-loader/postgres_loader.rb
@@ -24,6 +24,7 @@ module SnowPlow
       EVENT_FILES = "part-*"
       EVENT_FIELD_SEPARATOR = "	"
       NULL_STRING = ""
+      ESCAPE_STRING = "\\\\"
 
       # Loads the SnowPlow event files into Postgres.
       #
@@ -35,7 +36,7 @@ module SnowPlow
 
         event_files = get_event_files(events_dir)
         queries = event_files.map { |f|
-          "COPY #{target[:table]} FROM '#{f}' DELIMITER '#{EVENT_FIELD_SEPARATOR}' NULL '#{NULL_STRING}';"
+            "COPY #{target[:table]} FROM '#{f}' WITH CSV ESCAPE E'#{ESCAPE_STRING}' DELIMITER '#{EVENT_FIELD_SEPARATOR}' NULL '#{NULL_STRING}';"
         }
         
         status = execute_transaction(target, queries)


### PR DESCRIPTION
Here's the change that fixed my issue. Not sure if this has further implications (not a DBA).
