### PR TITLE
Add app and mob as valid platform codes #516

### DIFF
--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/MiscEnrichments.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/MiscEnrichments.scala
@@ -58,6 +58,8 @@ object MiscEnrichments {
     platform match {
       case "web" => "web".success // Web, including Mobile Web
       case "iot" => "iot".success // Internet of Things (e.g. Arduino tracker)
+      case "app" => "app".success // App
+      case "mob" => "mob".success // Mobile / Tablet
       case p => "Field [%s]: [%s] is not a supported tracking platform".format(field, p).fail
     }
   }

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/miscEnrichmentTests.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/miscEnrichmentTests.scala
@@ -52,6 +52,8 @@ class ExtractPlatformTest extends Specification with DataTables {
     "SPEC NAME"                      || "INPUT VAL" | "EXPECTED OUTPUT" |
     "valid web"                      !! "web"       ! "web".success     |
     "valid iot (internet of things)" !! "iot"       ! "iot".success     |
+    "valid app"                      !! "app"       ! "app".success     |
+    "valid mob"                      !! "mob"       ! "mob".success     |
     "invalid empty"                  !! ""          !  err("").fail     |
     "invalid null"                   !! null        !  err(null).fail   |
     "invalid platform"               !! "ma"        !  err("ma").fail   |> {


### PR DESCRIPTION
this adds mob and app as accepted values for platform as per https://github.com/snowplow/snowplow/wiki/snowplow-tracker-protocol
