### PR TITLE
Scala Stream Collector: add support for IAM roles

### DIFF
--- a/2-collectors/scala-stream-collector/src/main/resources/application.conf.example
+++ b/2-collectors/scala-stream-collector/src/main/resources/application.conf.example
@@ -59,9 +59,11 @@ collector {
 
     kinesis {
       # The following are used to authenticate for the Amazon Kinesis sink.
-      # 
+      #
       # If both are set to 'cpf', a properties file on the classpath is used.
       # http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/ClasspathPropertiesFileCredentialsProvider.html
+      #
+      # If both are set to 'iam', use AWS IAM Roles to provision credentials.
       aws {
         access-key: "cpf"
         secret-key: "cpf"


### PR DESCRIPTION
Add a new config option for aws.access-key and aws.secret-key.
If set to 'iam', use scalazon CredentialsProvider.InstanceProfile
to set up API credentials.
