### PR TITLE
Scala Stream Collector: replace stream list with describe to tighten permissions

### DIFF
--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/KinesisSink.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/KinesisSink.scala
@@ -68,19 +68,17 @@ class KinesisSink(config: CollectorConfig) extends AbstractSink {
 
   // Checks if a stream exists.
   def streamExists(name: String, timeout: Int = 60): Boolean = {
-    val streamListFuture = for {
-      s <- Kinesis.streams.list
+    val streamDescribeFuture = for {
+      s <- Kinesis.stream(name).describe
     } yield s
-    val streamList: Iterable[String] =
-      Await.result(streamListFuture, Duration(timeout, SECONDS))
-    for (streamStr <- streamList) {
-      if (streamStr == name) {
-        info(s"Stream $name exists")
-        return true
-      }
+    val description =
+      Await.result(streamDescribeFuture, Duration(timeout, SECONDS))
+    if (description.isActive) {
+      info(s"Stream $name exists and is active")
+      return true
     }
 
-    info(s"Stream $name doesn't exist")
+    info(s"Stream $name doesn't exist or is not active")
     false
   }
 


### PR DESCRIPTION
In the case where you want to use AWS roles to only grant
read/write permissions to a specific Kinesis Stream, this
change allows you to avoid using the kinesis:ListStream
action.

Instead, use kinesis:DescribeStream, which is targeted to
one specific stream and doesn't require visiblity to all
streams.

Additionally, this enables you to check whether the stream
has the status "active".
