### PR TITLE
scala-stream-collector: changes to allow for multiple sinks

### DIFF
--- a/2-collectors/scala-stream-collector/src/main/resources/application.conf.example
+++ b/2-collectors/scala-stream-collector/src/main/resources/application.conf.example
@@ -55,7 +55,7 @@ collector {
     #         to disable all logging.
     #      2. Using 'sbt assembly' and 'java -jar ...' to disable
     #         sbt logging.
-    enabled = "kinesis"
+    enabled = ["kinesis"]
 
     kinesis {
       # The following are used to authenticate for the Amazon Kinesis sink.

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
@@ -31,12 +31,12 @@ import sinks._
 
 // Actor accepting Http requests for the Scala collector.
 class CollectorServiceActor(collectorConfig: CollectorConfig,
-    sink: AbstractSink) extends Actor with HttpService {
+    sinks: List[AbstractSink]) extends Actor with HttpService {
   implicit val timeout: Timeout = 1.second // For the actor 'asks'
   def actorRefFactory = context
 
   // Deletage responses (content and storing) to the ResponseHandler.
-  private val responseHandler = new ResponseHandler(collectorConfig, sink)
+  private val responseHandler = new ResponseHandler(collectorConfig, sinks)
 
   // Use CollectorService so the same route can be accessed differently
   // in the testing framework.

--- a/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
+++ b/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
@@ -70,7 +70,7 @@ collector {
   }
 
   sink {
-    enabled = "test"
+    enabled = ["test"]
 
     kinesis {
       aws {
@@ -86,8 +86,8 @@ collector {
 }
 """)
   val collectorConfig = new CollectorConfig(testConf)
-  val sink = new TestSink
-  val responseHandler = new ResponseHandler(collectorConfig, sink)
+  val sinks = List(new TestSink)
+  val responseHandler = new ResponseHandler(collectorConfig, sinks)
   val collectorService = new CollectorService(responseHandler, system)
   val thriftDeserializer = new TDeserializer
 
@@ -174,7 +174,7 @@ collector {
       storedEvent.timestamp must beCloseTo(DateTime.now.clicks, 1000)
       storedEvent.encoding must beEqualTo("UTF-8")
       storedEvent.ipAddress must beEqualTo("127.0.0.1")
-      storedEvent.collector must beEqualTo("ssc-0.1.0-test")
+      storedEvent.collector must beEqualTo("ssc-0.1.0")
       storedEvent.payload.protocol must beEqualTo(PayloadProtocol.Http)
       storedEvent.payload.format must beEqualTo(PayloadFormat.HttpGet)
       storedEvent.payload.data must beEqualTo(payloadData)


### PR DESCRIPTION
Instead creating, passing around, and calling functions on individual
`AbstractSinks`, use a `List` of `AbstractSinks`.
- amended the example config to use `[]` array notation
- spectest goodness

References the discussion in #506

Two changes that I'm not sure of:
1) I changed the Collector name string to omit the `"-${sinkType}"` (e.g. `"-test"` at the end of the name. I chose this over two other options
- Appending all the collector names `-sinktype1-sinktype2-sinktypeN`-- didn't seem sensible to me
- For each sink, log a different `SnowplowRawEvent` with a different collector name -- didn't seem right to me

2) For the sake of testing, the `sinkResponse` is returned. In this new paradigm I just went with returning `sinkResponses(0)` but in practice this could cause a runtime exception if the list is empty.

Thoughts are welcome and appreciated!! Thanks.
