### PR TITLE
Remove ssl from tracking pixel since cert invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-![Tracker](https://collector.snplow.com/i?&e=pv&page=Root%20README&aid=snowplowgithub&p=web&tv=no-js-0.1.0)
+![Tracker](http://collector.snplow.com/i?&e=pv&page=Root%20README&aid=snowplowgithub&p=web&tv=no-js-0.1.0)
 
 [website]: http://snowplowanalytics.com
 [wiki]: https://github.com/snowplow/snowplow/wiki


### PR DESCRIPTION
Tracking pixel on readme is broken because there is no cert for https://collector.snplow.com/.  This PR changes the tracking pixel to use http instead of https.
