### PR TITLE
Use Future for writing to sink.

### DIFF
--- a/2-collectors/scala-stream-collector/src/main/resources/application.conf.example
+++ b/2-collectors/scala-stream-collector/src/main/resources/application.conf.example
@@ -58,6 +58,8 @@ collector {
     enabled = "kinesis"
 
     kinesis {
+      thread-pool-size: 10 # Thread pool size for Kinesis API requests
+
       # The following are used to authenticate for the Amazon Kinesis sink.
       # 
       # If both are set to 'cpf', a properties file on the classpath is used.

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/ResponseHandler.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/ResponseHandler.scala
@@ -32,6 +32,9 @@ import spray.http.HttpHeaders.{
 }
 import spray.http.MediaTypes.`image/gif`
 
+// Akka
+import akka.actor.ActorRefFactory
+
 // Typesafe config
 import com.typesafe.config.Config
 
@@ -51,7 +54,9 @@ object ResponseHandler {
 }
 
 // Receive requests and store data into an output sink.
-class ResponseHandler(config: CollectorConfig, sink: AbstractSink) {
+class ResponseHandler(config: CollectorConfig, sink: AbstractSink)(implicit context: ActorRefFactory) {
+
+  import context.dispatcher
   
   val Collector = s"${generated.Settings.shortName}-${generated.Settings.version}-" + config.sinkEnabled.toString.toLowerCase
 

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/ScalaCollectorApp.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/ScalaCollectorApp.scala
@@ -135,5 +135,10 @@ class CollectorConfig(config: Config) {
   private val stream = kinesis.getConfig("stream")
   val streamName = stream.getString("name")
   val streamSize = stream.getInt("size")
+
+  val threadpoolSize = kinesis.hasPath("thread-pool-size") match {
+    case true => kinesis.getInt("thread-pool-size")
+    case _ => 10
+  }
 }
 

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/TestSink.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/TestSink.scala
@@ -39,6 +39,6 @@ import thrift.SnowplowRawEvent
 // Allow the testing framework to test collection events using the
 // same methods from AbstractSink as the other sinks.
 class TestSink extends AbstractSink {
-  def storeRawEvent(event: SnowplowRawEvent, key: String): Array[Byte] =
+  def storeRawEvent(event: SnowplowRawEvent, key: String) =
     serializeEvent(event)
 }

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/KinesisSink.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/KinesisSink.scala
@@ -39,7 +39,6 @@ import com.typesafe.config.Config
 
 // Concurrent libraries
 import scala.concurrent.{Future,Await,TimeoutException}
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 // Logging
@@ -48,6 +47,7 @@ import org.slf4j.LoggerFactory
 // Mutable data structures
 import scala.collection.mutable.StringBuilder
 import scala.collection.mutable.MutableList
+import scala.util.{Success, Failure}
 
 // Snowplow
 import scalastream._
@@ -59,6 +59,12 @@ import thrift.SnowplowRawEvent
 class KinesisSink(config: CollectorConfig) extends AbstractSink {
   private lazy val log = LoggerFactory.getLogger(getClass())
   import log.{error, debug, info, trace}
+
+  implicit lazy val ec = {
+    info("Creating thread pool of size " + config.threadpoolSize)
+    val executorService = java.util.concurrent.Executors.newFixedThreadPool(config.threadpoolSize)
+    concurrent.ExecutionContext.fromExecutorService(executorService)
+  }
 
   // Create a Kinesis client for stream interactions.
   private implicit val kinesis = createKinesisClient
@@ -99,7 +105,7 @@ class KinesisSink(config: CollectorConfig) extends AbstractSink {
 
       try {
         val stream = Await.result(createStream, Duration(timeout, SECONDS))
-        
+
         info(s"Successfully created stream $name. Waiting until it's active")
         Await.result(stream.waitActive.retrying(timeout),
           Duration(timeout, SECONDS))
@@ -133,7 +139,7 @@ class KinesisSink(config: CollectorConfig) extends AbstractSink {
     }
   }
 
-  def storeRawEvent(event: SnowplowRawEvent, key: String): Array[Byte] = {
+  def storeRawEvent(event: SnowplowRawEvent, key: String) = {
     info(s"Writing Thrift record to Kinesis: ${event.toString}")
     val putData = for {
       p <- enrichedStream.put(
@@ -141,11 +147,20 @@ class KinesisSink(config: CollectorConfig) extends AbstractSink {
         key
       )
     } yield p
-    val result = Await.result(putData, Duration(60, SECONDS))
-    info(s"Writing successful.")
-    info(s"  + ShardId: ${result.shardId}")
-    info(s"  + SequenceNumber: ${result.sequenceNumber}")
-    null // TODO: yech
+
+    putData onComplete {
+      case Success(result) => {
+        info(s"Writing successful.")
+        info(s"  + ShardId: ${result.shardId}")
+        info(s"  + SequenceNumber: ${result.sequenceNumber}")
+      }
+      case Failure(f) => {
+        error(s"Writing failed.")
+        error(s"  + " + f.getMessage)
+      }
+    }
+
+    null
   }
 
   /**


### PR DESCRIPTION
Performance improvement to `scala-stream-collector`.

I applied this patch `StdoutSink` to simulate a 50ms delay in writing to the sink (the Kinesis sink uses Await to wait for the response and log it).

``` diff
@@ -36,10 +36,19 @@ import com.typesafe.config.Config
 import scalastream._
 import thrift.SnowplowRawEvent

+import scala.concurrent._
+import scala.concurrent.duration._
+import ExecutionContext.Implicits.global
+
 class StdoutSink extends AbstractSink {
   // Print a Base64-encoded event.
   def storeRawEvent(event: SnowplowRawEvent, key: String) = {
-    println(Base64.encodeBase64String(serializeEvent(event)))
+    val decode = Future {
+      Thread.sleep(50)
+      Base64.encodeBase64String(serializeEvent(event))
+    }
+    val result = Await.result(decode, Duration(60, SECONDS))
+    println(result)
     null
   }
 }
```

Here is the performance running siege before my change:

```
siege -b -c30 -t60s  http://localhost:8080/i
Transactions:               1135 hits
Availability:              74.43 %
Elapsed time:              59.30 secs
Data transferred:           0.04 MB
Response time:              1.20 secs
Transaction rate:          19.14 trans/sec
Throughput:             0.00 MB/sec
Concurrency:               23.04
Successful transactions:        1135
Failed transactions:             390
Longest transaction:            2.52
Shortest transaction:           0.06
```

Seems like it was halting quite badly, so pulling the sink write out of the scope of the HTTP request means it's able to respond much faster.

```
Transactions:              32591 hits
Availability:             100.00 %
Elapsed time:              59.40 secs
Data transferred:           1.15 MB
Response time:              0.05 secs
Transaction rate:         548.67 trans/sec
Throughput:             0.02 MB/sec
Concurrency:               25.96
Successful transactions:       32591
Failed transactions:               0
Longest transaction:           13.57
Shortest transaction:           0.00
```
