### PR TITLE
Add AWS Kinesis Redshift sink

### DIFF
--- a/4-storage/kinesis-redshift-sink/.gitignore
+++ b/4-storage/kinesis-redshift-sink/.gitignore
@@ -1,0 +1,3 @@
+target/
+AwsCredentials.properties
+*.class

--- a/4-storage/kinesis-redshift-sink/LICENSE.txt
+++ b/4-storage/kinesis-redshift-sink/LICENSE.txt
@@ -1,0 +1,40 @@
+
+Amazon Software License
+
+This Amazon Software License (“License”) governs your use, reproduction, and distribution of the accompanying software as specified below.
+1. Definitions
+
+“Licensor” means any person or entity that distributes its Work.
+
+“Software” means the original work of authorship made available under this License.
+
+“Work” means the Software and any additions to or derivative works of the Software that are made available under this License.
+
+The terms “reproduce,” “reproduction,” “derivative works,” and “distribution” have the meaning as provided under U.S. copyright law; provided, however, that for the purposes of this License, derivative works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work.
+
+Works, including the Software, are “made available” under this License by including in or with the Work either (a) a copyright notice referencing the applicability of this License to the Work, or (b) a copy of this License.
+2. License Grants
+
+2.1 Copyright Grant. Subject to the terms and conditions of this License, each Licensor grants to you a perpetual, worldwide, non-exclusive, royalty-free, copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense and distribute its Work and any resulting derivative works in any form.
+
+2.2 Patent Grant. Subject to the terms and conditions of this License, each Licensor grants to you a perpetual, worldwide, non-exclusive, royalty-free patent license to make, have made, use, sell, offer for sale, import, and otherwise transfer its Work, in whole or in part. The foregoing license applies only to the patent claims licensable by Licensor that would be infringed by Licensor’s Work (or portion thereof) individually and excluding any combinations with any other materials or technology.
+3. Limitations
+
+3.1 Redistribution. You may reproduce or distribute the Work only if (a) you do so under this License, (b) you include a complete copy of this License with your distribution, and (c) you retain without modification any copyright, patent, trademark, or attribution notices that are present in the Work.
+
+3.2 Derivative Works. You may specify that additional or different terms apply to the use, reproduction, and distribution of your derivative works of the Work (“Your Terms”) only if (a) Your Terms provide that the use limitation in Section 3.3 applies to your derivative works, and (b) you identify the specific derivative works that are subject to Your Terms. Notwithstanding Your Terms, this License (including the redistribution requirements in Section 3.1) will continue to apply to the Work itself.
+
+3.3 Use Limitation. The Work and any derivative works thereof only may be used or intended for use with the web services, computing platforms or applications provided by Amazon.com, Inc. or its affiliates, including Amazon Web Services, Inc.
+
+3.4 Patent Claims. If you bring or threaten to bring a patent claim against any Licensor (including any claim, cross-claim or counterclaim in a lawsuit) to enforce any patents that you allege are infringed by any Work, then your rights under this License from such Licensor (including the grants in Sections 2.1 and 2.2) will terminate immediately.
+
+3.5 Trademarks. This License does not grant any rights to use any Licensor’s or its affiliates’ names, logos, or trademarks, except as necessary to reproduce the notices described in this License.
+
+3.6 Termination. If you violate any term of this License, then your rights under this License (including the grants in Sections 2.1 and 2.2) will terminate immediately.
+4. Disclaimer of Warranty.
+
+THE WORK IS PROVIDED “AS IS” WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WARRANTIES OR CONDITIONS OF M ERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE OR NON-INFRINGEMENT. YOU BEAR THE RISK OF UNDERTAKING ANY ACTIVITIES UNDER THIS LICENSE. SOME STATES’ CONSUMER LAWS DO NOT ALLOW EXCLUSION OF AN IMPLIED WARRANTY, SO THIS DISCLAIMER MAY NOT APPLY TO YOU.
+5. Limitation of Liability.
+
+EXCEPT AS PROHIBITED BY APPLICABLE LAW, IN NO EVENT AND UNDER NO LEGAL THEORY, WHETHER IN TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE SHALL ANY LICENSOR BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR RELATED TO THIS LICENSE, THE USE OR INABILITY TO USE THE WORK (INCLUDING BUT NOT LIMITED TO LOSS OF GOODWILL, BUSINESS INTERRUPTION, LOST PROFITS OR DATA, COMPUTER FAILURE OR MALFUNCTION, OR ANY OTHER COMM ERCIAL DAMAGES OR LOSSES), EVEN IF THE LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+

--- a/4-storage/kinesis-redshift-sink/NOTICE.txt
+++ b/4-storage/kinesis-redshift-sink/NOTICE.txt
@@ -1,0 +1,3 @@
+Amazon Kinesis Connector Library
+Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+

--- a/4-storage/kinesis-redshift-sink/README.md
+++ b/4-storage/kinesis-redshift-sink/README.md
@@ -1,0 +1,69 @@
+# Java Kinesis Redshift Sink for SnowPlow
+
+## Introduction
+
+Java Kinesis Redshift Sink processes Snowplow events, in the [Canonical
+Output][canonical-output] format, from an input [Amazon Kinesis][kinesis]
+stream and stores them into a Redshift database.
+
+This work derives from the sample Kinesis Applications and connectors library
+included in the [amazon-kinesis-connectors][connectors] project.
+
+Java Kinesis Redshift Sink two different ways to upload your events to
+Redshift. The Kinesis Redshift Basic Sink, reads events from an input Kinesis
+stream and pushes these into a local buffer; as soon as the buffer will get
+enough records (configured via the `bufferRecordCountLimit` and
+`bufferSizeByteLimit` settings), data are copied to an S3 bucket to be imported
+into the Redshift database. 
+
+The Kinesis Redshift Manifest Sink works almost like the Basic one but it reduces the calls
+to Redshift by buffering more data to S3 and importing them into Redshift all
+together via a [Manifest][redshift-manifest] file; once the Manifest is
+written to S3, the Manifest Sink will publish the name of the file to the
+output Kinesis stream, where it will then be read and sent to Redshift.
+
+## Usage
+
+Java Kinesis Redshift Sink expects its configurations to be defined in the
+`src/main/resources` directory. There you can find three different files, one
+for each Kinesis Application:
+
+- `RedshiftBasic.properties`: here you configure the input Kinesis stream and the
+  S3 bucket used to feed data into Redshift
+- `RedshiftManifest.properties`: here you configure the input Kinesis
+  stream and the S3 bucket. Note: the input stream for this Kinesis app should
+  be the output stream from the one configured via the `S3Manifest.properties`
+  app.
+- `S3Manifest.properties`: configure the S3 bucket to store events data and
+  manifest files, and the input and output Kinesis streams. The output stream
+  will be used to publish the name of the Manifest file.
+
+Notice that, you need to configure your settings before building the Java
+Kinesis Sink apps, since these are included in the built jar.
+
+## Building
+
+Assuming you already have [Maven][mvn] installed:
+
+```bash
+$ mvn clean compile assembly:single
+```
+
+## Running
+
+```bash
+$ java -jar target/kinesis-redshift-sink-0.0.1-jar-with-dependencies.jar
+```
+
+## Copyright and license
+
+See the [LICENSE](LICENSE.txt) file.
+
+[kinesis]: http://aws.amazon.com/kinesis/
+[snowplow]: http://snowplowanalytics.com
+[redshift-manifest]:
+http://docs.aws.amazon.com/redshift/latest/dg/loading-data-files-using-manifest.html
+[canonical-output]:
+https://github.com/snowplow/snowplow/wiki/canonical-event-model
+[connectors]: https://github.com/awslabs/amazon-kinesis-connectors
+[mvn]: http://maven.apache.org/

--- a/4-storage/kinesis-redshift-sink/pom.xml
+++ b/4-storage/kinesis-redshift-sink/pom.xml
@@ -1,0 +1,87 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.amazonaws.services.kinesis.connectors</groupId>
+  <artifactId>kinesis-redshift-sink</artifactId>
+  <version>0.0.1</version>
+  <packaging>jar</packaging>
+
+  <name>kinesis-redshift-sink</name>
+  <url>http://snowplow</url>
+
+  <repositories>
+    <repository>
+      <id>amazon-kinesis-connectors</id>
+      <name>amazon kinesis connector repo</name>
+      <url>https://raw.githubusercontent.com/pkallos/amazon-kinesis-connectors/mvn-repo/</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>amazon-kinesis-client</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>amazon-kinesis-connector</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>9.3-1101-jdbc41</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.7</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <source>1.7</source>
+            <target>1.7</target>
+            <encoding>UTF-8</encoding>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>com.snowplowanalytics.snowplow.kinesis.redshiftbasic.RedshiftBasicExecutor</mainClass>
+            </manifest>
+          </archive>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/KinesisConnectorExecutor.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/KinesisConnectorExecutor.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.snowplowanalytics.snowplow.kinesis;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import com.snowplowanalytics.snowplow.kinesis.utils.DynamoDBUtils;
+import com.snowplowanalytics.snowplow.kinesis.utils.KinesisUtils;
+import com.snowplowanalytics.snowplow.kinesis.utils.RedshiftUtils;
+import com.snowplowanalytics.snowplow.kinesis.utils.S3Utils;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
+import com.amazonaws.services.kinesis.connectors.KinesisConnectorConfiguration;
+import com.amazonaws.services.kinesis.connectors.KinesisConnectorExecutorBase;
+import com.amazonaws.services.redshift.AmazonRedshiftClient;
+import com.amazonaws.services.s3.AmazonS3Client;
+
+/**
+ * This class defines the execution of a Kinesis Connector.
+ * 
+ */
+public abstract class KinesisConnectorExecutor<T,U> extends KinesisConnectorExecutorBase<T,U> {
+
+    // Create AWS Resource constants
+    private static final String CREATE_KINESIS_INPUT_STREAM = "createKinesisInputStream";
+    private static final String CREATE_KINESIS_OUTPUT_STREAM = "createKinesisOutputStream";
+    private static final String CREATE_DYNAMODB_DATA_TABLE = "createDynamoDBDataTable";
+    private static final String CREATE_REDSHIFT_CLUSTER = "createRedshiftCluster";
+    private static final String CREATE_REDSHIFT_DATA_TABLE = "createRedshiftDataTable";
+    private static final String CREATE_REDSHIFT_FILE_TABLE = "createRedshiftFileTable";
+    private static final String CREATE_S3_BUCKET = "createS3Bucket";
+    private static final boolean DEFAULT_CREATE_RESOURCES = false;
+
+    // Create Kinesis Resource constants
+    private static final String KINESIS_INPUT_STREAM_SHARD_COUNT = "kinesisInputStreamShardCount";
+    private static final String KINESIS_OUTPUT_STREAM_SHARD_COUNT = "kinesisOutpuStreamShardCount";
+    private static final int DEFAULT_KINESIS_SHARD_COUNT = 1;
+
+    // Create DynamoDB Resource constants
+    private static final String DYNAMODB_KEY = "dynamoDBKey";
+    private static final String DYNAMODB_READ_CAPACITY_UNITS = "readCapacityUnits";
+    private static final String DYNAMODB_WRITE_CAPACITY_UNITS = "writeCapacityUnits";
+    private static final Long DEFAULT_DYNAMODB_READ_CAPACITY_UNITS = 1l;
+    private static final Long DEFAULT_DYNAMODB_WRITE_CAPACITY_UNITS = 1l;
+
+    // Create Redshift Resource constants
+    private static final String REDSHIFT_CLUSTER_IDENTIFIER = "redshiftClusterIdentifier";
+    private static final String REDSHIFT_DATABASE_NAME = "redshiftDatabaseName";
+    private static final String REDSHIFT_CLUSTER_TYPE = "redshiftClusterType";
+    private static final String REDSHIFT_NUMBER_OF_NODES = "redshiftNumberOfNodes";
+    private static final int DEFAULT_REDSHIFT_NUMBER_OF_NODES = 2;
+
+    // Create S3 Resource constants
+    private static final String S3_BUCKET = "s3Bucket";
+
+    // Class variables
+    protected final KinesisConnectorConfiguration config;
+    private final Properties properties;
+
+    /**
+     * Create a new KinesisConnectorExecutor based on the provided configuration (*.propertes) file
+     * 
+     * @param configFile
+     *            The name of the configuration file to look for on the classpath
+     */
+    public KinesisConnectorExecutor(String configFile) {
+        InputStream configStream = Thread.currentThread().getContextClassLoader()
+                .getResourceAsStream(configFile);
+
+        if (configStream == null) {
+            String msg = "Could not find resource " + configFile + " in the classpath";
+            throw new IllegalStateException(msg);
+        }
+        properties = new Properties();
+        try {
+            properties.load(configStream);
+            configStream.close();
+        } catch (IOException e) {
+            String msg = "Could not load properties file " + configFile + " from classpath";
+            throw new IllegalStateException(msg, e);
+        }
+        this.config = new KinesisConnectorConfiguration(properties, getAWSCredentialsProvider());
+        setupAWSResources();
+        
+        // Initialize executor with configurations
+        super.initialize(config);
+    }
+
+    /**
+     * Returns an {@link AWSCredentialsProvider} with the permissions necessary to accomplish all specified
+     * tasks. At the minimum it will require Kinesis read permissions. Additional read permissions
+     * and write permissions may be required based on the Pipeline used
+     * 
+     * @return
+     */
+    public AWSCredentialsProvider getAWSCredentialsProvider() {
+        return new DefaultAWSCredentialsProviderChain();
+    }
+
+    /**
+     * Setup necessary AWS resources for the samples. By default, the Executor does not create any
+     * AWS resources. The user must specify true for the specific create properties in the
+     * configuration file.
+     */
+    private void setupAWSResources() {
+        if (parseBoolean(CREATE_KINESIS_INPUT_STREAM, DEFAULT_CREATE_RESOURCES, properties)) {
+            int shardCount = parseInt(KINESIS_INPUT_STREAM_SHARD_COUNT, DEFAULT_KINESIS_SHARD_COUNT,
+                    properties);
+            KinesisUtils.createInputStream(config, shardCount);
+        }
+        
+        if (parseBoolean(CREATE_KINESIS_OUTPUT_STREAM, DEFAULT_CREATE_RESOURCES, properties)) {
+            int shardCount = parseInt(KINESIS_OUTPUT_STREAM_SHARD_COUNT, DEFAULT_KINESIS_SHARD_COUNT,
+                    properties);
+            KinesisUtils.createOutputStream(config, shardCount);
+        }
+        
+        if (parseBoolean(CREATE_DYNAMODB_DATA_TABLE, DEFAULT_CREATE_RESOURCES, properties)) {
+            String key = properties.getProperty(DYNAMODB_KEY);
+            Long readCapacityUnits = parseLong(DYNAMODB_READ_CAPACITY_UNITS,
+                    DEFAULT_DYNAMODB_READ_CAPACITY_UNITS, properties);
+            Long writeCapacityUnits = parseLong(DYNAMODB_WRITE_CAPACITY_UNITS,
+                    DEFAULT_DYNAMODB_WRITE_CAPACITY_UNITS, properties);
+            createDynamoDBTable(key, readCapacityUnits, writeCapacityUnits);
+        }
+        
+        if (parseBoolean(CREATE_REDSHIFT_CLUSTER, DEFAULT_CREATE_RESOURCES, properties)) {
+            String clusterIdentifier = properties.getProperty(REDSHIFT_CLUSTER_IDENTIFIER);
+            String databaseName = properties.getProperty(REDSHIFT_DATABASE_NAME);
+            String clusterType = properties.getProperty(REDSHIFT_CLUSTER_TYPE);
+            int numberOfNodes = parseInt(REDSHIFT_NUMBER_OF_NODES, DEFAULT_REDSHIFT_NUMBER_OF_NODES,
+                    properties);
+            createRedshiftCluster(clusterIdentifier, databaseName, clusterType, numberOfNodes);
+        }
+        
+        if (parseBoolean(CREATE_REDSHIFT_DATA_TABLE, DEFAULT_CREATE_RESOURCES, properties)) {
+            createRedshiftDataTable();
+        }
+        
+        if (parseBoolean(CREATE_REDSHIFT_FILE_TABLE, DEFAULT_CREATE_RESOURCES, properties)) {
+            createRedshiftFileTable();
+        }
+        
+        if (parseBoolean(CREATE_S3_BUCKET, DEFAULT_CREATE_RESOURCES, properties)) {
+            String s3Bucket = properties.getProperty(S3_BUCKET);
+            createS3Bucket(s3Bucket);
+        }
+    }
+
+    /**
+     * Helper method to create the DynamoDB table
+     * 
+     * @param key
+     *            The name of the hashkey field in the DynamoDB table
+     * @param readCapacityUnits
+     *            Read capacity of the DynamoDB table
+     * @param writeCapacityUnits
+     *            Write capacity of the DynamoDB table
+     */
+    private void createDynamoDBTable(String key, long readCapacityUnits, long writeCapacityUnits) {
+        DynamoDBUtils.createTable(new AmazonDynamoDBClient(config.AWS_CREDENTIALS_PROVIDER),
+                config.DYNAMODB_DATA_TABLE_NAME, key, readCapacityUnits, writeCapacityUnits);
+    }
+
+    /**
+     * Helper method to create the Redshift cluster
+     * 
+     * @param clusterIdentifier
+     *            Unique identifier for the name of the Redshift cluster
+     * @param databaseName
+     *            Name for the database in the Redshift cluster
+     * @param clusterType
+     *            dw.hs1.xlarge or dw.hs1.8xlarge
+     * @param numberOfNodes
+     *            Number of nodes for the Redshift cluster
+     */
+    private void createRedshiftCluster(String clusterIdentifier, String databaseName, String clusterType,
+            int numberOfNodes) {
+        // Make sure Redshift cluster is available
+        AmazonRedshiftClient redshiftClient = new AmazonRedshiftClient(config.AWS_CREDENTIALS_PROVIDER);
+        redshiftClient.setEndpoint(config.REDSHIFT_ENDPOINT);
+        RedshiftUtils.createCluster(redshiftClient, clusterIdentifier, databaseName,
+                config.REDSHIFT_USERNAME, config.REDSHIFT_PASSWORD, clusterType, numberOfNodes);
+
+        // Update Redshift connection url
+        config.REDSHIFT_URL = RedshiftUtils.getClusterURL(redshiftClient, clusterIdentifier);
+    }
+
+    /**
+     * Helper method to create the data table in Redshift
+     *
+     * @deprecated
+     */
+    @Deprecated
+    private void createRedshiftDataTable() {
+        Properties p = new Properties();
+        p.setProperty("user", config.REDSHIFT_USERNAME);
+        p.setProperty("password", config.REDSHIFT_PASSWORD);
+        if (RedshiftUtils.tableExists(p, config.REDSHIFT_URL, config.REDSHIFT_DATA_TABLE)) {
+            return;
+        }
+        try {
+            RedshiftUtils.createRedshiftTable(config.REDSHIFT_URL, p, config.REDSHIFT_DATA_TABLE,
+                    getKinesisMessageModelFields());
+        } catch (SQLException e) {
+            String msg = "Could not create Redshift data table " + config.REDSHIFT_DATA_TABLE;
+            throw new IllegalStateException(msg, e);
+        }
+    }
+
+    /**
+     * Helper method to create the file table in Redshift
+     */
+    private void createRedshiftFileTable() {
+        Properties p = new Properties();
+        p.setProperty("user", config.REDSHIFT_USERNAME);
+        p.setProperty("password", config.REDSHIFT_PASSWORD);
+        if (RedshiftUtils.tableExists(p, config.REDSHIFT_URL, config.REDSHIFT_FILE_TABLE)) {
+            return;
+        }
+        try {
+            RedshiftUtils.createRedshiftTable(config.REDSHIFT_URL, p, config.REDSHIFT_FILE_TABLE,
+                    getFileTableFields());
+        } catch (SQLException e) {
+            String msg = "Could not create Redshift file table " + config.REDSHIFT_FILE_TABLE;
+            throw new IllegalStateException(msg, e);
+        }
+    }
+
+    /**
+     * Helper method to build the data table
+     * 
+     * @return Fields for the data table
+     *
+     * @deprecated
+     */
+    @Deprecated
+    private static List<String> getKinesisMessageModelFields() {
+        List<String> fields = new ArrayList<String>();
+        fields.add("userid integer not null distkey sortkey");
+        fields.add("username char(8)");
+        fields.add("firstname varchar(30)");
+        fields.add("lastname varchar(30)");
+        fields.add("city varchar(30)");
+        fields.add("state char(2)");
+        fields.add("email varchar(100)");
+        fields.add("phone char(14)");
+        fields.add("likesports boolean");
+        fields.add("liketheatre boolean");
+        fields.add("likeconcerts boolean");
+        fields.add("likejazz boolean");
+        fields.add("likeclassical boolean");
+        fields.add("likeopera boolean");
+        fields.add("likerock boolean");
+        fields.add("likevegas boolean");
+        fields.add("likebroadway boolean");
+        fields.add("likemusicals boolean");
+        return fields;
+    }
+
+    /**
+     * Helper method to help create the file table
+     * 
+     * @return File table fields
+     */
+    private static List<String> getFileTableFields() {
+        List<String> fields = new ArrayList<String>();
+        fields.add("file varchar(255) primary key");
+        return fields;
+    }
+
+    /**
+     * Helper method to create the S3Bucket
+     * 
+     * @param s3Bucket
+     *            The name of the bucket to create
+     */
+    private void createS3Bucket(String s3Bucket) {
+        AmazonS3Client client = new AmazonS3Client(config.AWS_CREDENTIALS_PROVIDER);
+        client.setEndpoint(config.S3_ENDPOINT);
+        S3Utils.createBucket(client, s3Bucket);
+    }
+
+    /**
+     * Helper method used to parse boolean properties
+     * 
+     * @param property
+     *            The String key for the property
+     * @param defaultValue
+     *            The default value for the boolean property
+     * @param properties
+     *            The properties file to get property from
+     * @return property from property file, or if it is not specified, the default value
+     */
+    private static boolean parseBoolean(String property, boolean defaultValue, Properties properties) {
+        return Boolean.parseBoolean(properties.getProperty(property, Boolean.toString(defaultValue)));
+    }
+
+    /**
+     * Helper method used to parse long properties
+     * 
+     * @param property
+     *            The String key for the property
+     * @param defaultValue
+     *            The default value for the long property
+     * @param properties
+     *            The properties file to get property from
+     * @return property from property file, or if it is not specified, the default value
+     */
+    private static long parseLong(String property, long defaultValue, Properties properties) {
+        return Long.parseLong(properties.getProperty(property, Long.toString(defaultValue)));
+    }
+
+    /**
+     * Helper method used to parse integer properties
+     * 
+     * @param property
+     *            The String key for the property
+     * @param defaultValue
+     *            The default value for the integer property
+     * @param properties
+     *            The properties file to get property from
+     * @return property from property file, or if it is not specified, the default value
+     */
+    private static int parseInt(String property, int defaultValue, Properties properties) {
+        return Integer.parseInt(properties.getProperty(property, Integer.toString(defaultValue)));
+    }
+}

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/KinesisConnectorMetricsExecutor.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/KinesisConnectorMetricsExecutor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.snowplowanalytics.snowplow.kinesis;
+
+import com.amazonaws.services.kinesis.metrics.impl.CWMetricsFactory;
+import com.amazonaws.services.kinesis.metrics.interfaces.IMetricsFactory;
+
+/**
+ * This class defines the execution of a Kinesis Connector with CloudWatch metrics.
+ * 
+ */
+public abstract class KinesisConnectorMetricsExecutor<T,U> extends KinesisConnectorExecutor<T,U> {
+
+    /**
+     * Creates a new KinesisConnectorMetricsExecutor
+     * @param configFile The name of the configuration file to look for on the classpath
+     */
+    public KinesisConnectorMetricsExecutor(String configFile) {
+        super(configFile);
+        
+        // CloudWatch Metrics Factory used to emit metrics in KCL
+        IMetricsFactory mFactory = new CWMetricsFactory(config.AWS_CREDENTIALS_PROVIDER,
+                config.CLOUDWATCH_NAMESPACE, config.CLOUDWATCH_BUFFER_TIME, config.CLOUDWATCH_MAX_QUEUE_SIZE);
+        super.initialize(config, mFactory);
+    }
+}

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/redshiftbasic/RedshiftBasicExecutor.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/redshiftbasic/RedshiftBasicExecutor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.snowplowanalytics.snowplow.kinesis.redshiftbasic;
+
+import com.snowplowanalytics.snowplow.kinesis.KinesisConnectorExecutor;
+
+import com.amazonaws.services.kinesis.connectors.KinesisConnectorRecordProcessorFactory;
+
+/**
+ * The Executor for the basic Redshift emitter sample.
+ */
+public class RedshiftBasicExecutor extends KinesisConnectorExecutor<String, byte[]> {
+    private static final String CONFIG_FILE = "RedshiftBasic.properties";
+
+    /**
+     * Creates a new RedshiftBasicExecutor.
+     * @param configFile The name of the configuration file to look for on the classpath
+     */
+    public RedshiftBasicExecutor(String configFile) {
+        super(configFile);
+    }
+
+    @Override
+    public KinesisConnectorRecordProcessorFactory<String, byte[]> getKinesisConnectorRecordProcessorFactory() {
+        return new KinesisConnectorRecordProcessorFactory<>(new RedshiftBasicPipeline(), config);
+    }
+
+    /**
+     * Main method starts and runs the RedshiftBasicExecutor.
+     * @param args
+     */
+    public static void main(String[] args) {
+        try {
+            Class.forName("org.postgresql.Driver");
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Could not load PostgreSQL driver");
+        }
+        KinesisConnectorExecutor<String, byte[]> redshiftExecutor = new RedshiftBasicExecutor(
+                CONFIG_FILE);
+        redshiftExecutor.run();
+    }
+}

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/redshiftbasic/RedshiftBasicPipeline.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/redshiftbasic/RedshiftBasicPipeline.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.snowplowanalytics.snowplow.kinesis.redshiftbasic;
+
+import com.amazonaws.services.kinesis.connectors.KinesisConnectorConfiguration;
+import com.amazonaws.services.kinesis.connectors.impl.AllPassFilter;
+import com.amazonaws.services.kinesis.connectors.impl.BasicMemoryBuffer;
+import com.amazonaws.services.kinesis.connectors.impl.StringToByteArrayTransformer;
+import com.amazonaws.services.kinesis.connectors.interfaces.IBuffer;
+import com.amazonaws.services.kinesis.connectors.interfaces.IEmitter;
+import com.amazonaws.services.kinesis.connectors.interfaces.IFilter;
+import com.amazonaws.services.kinesis.connectors.interfaces.IKinesisConnectorPipeline;
+import com.amazonaws.services.kinesis.connectors.interfaces.ITransformer;
+import com.amazonaws.services.kinesis.connectors.redshift.RedshiftBasicEmitter;
+
+/**
+ * The Pipeline used by the Redshift basic sample. Uses:
+ * <ul>
+ * <li>{@link RedshiftBasicEmitter}</li>
+ * <li>{@link BasicMemoryBuffer}</li>
+ * <li>{@link StringToByteArrayTransformer}</li>
+ * <li>{@link AllPassFilter}</li>
+ * </ul>
+ */
+public class RedshiftBasicPipeline implements IKinesisConnectorPipeline<String, byte[]> {
+
+    @Override
+    public IEmitter<byte[]> getEmitter(KinesisConnectorConfiguration configuration) {
+        return new RedshiftBasicEmitter(configuration);
+    }
+
+    @Override
+    public IBuffer<String> getBuffer(KinesisConnectorConfiguration configuration) {
+        return new BasicMemoryBuffer<String>(configuration);
+    }
+
+    @Override
+    public ITransformer<String, byte[]> getTransformer(KinesisConnectorConfiguration configuration) {
+        return new StringToByteArrayTransformer();
+    }
+
+    @Override
+    public IFilter<String> getFilter(KinesisConnectorConfiguration configuration) {
+        return new AllPassFilter<String>();
+    }
+
+}

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/redshiftmanifest/RedshiftManifestExecutor.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/redshiftmanifest/RedshiftManifestExecutor.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.snowplowanalytics.snowplow.kinesis.redshiftmanifest;
+
+import com.snowplowanalytics.snowplow.kinesis.KinesisConnectorExecutor;
+
+import com.amazonaws.services.kinesis.connectors.KinesisConnectorRecordProcessorFactory;
+
+/**
+ * The executor used to read S3 file names from the secondary Kinesis stream, create a manifest file
+ * in S3, and then perform a Redshift manifest copy.
+ */
+public class RedshiftManifestExecutor extends KinesisConnectorExecutor<String, String> {
+
+    /**
+     * Creates a new RedshiftManifestExecutor.
+     * 
+     * @param configFile
+     *            The name of the configuration file to look for on the classpath.
+     */
+    public RedshiftManifestExecutor(String configFile) {
+        super(configFile);
+    }
+
+    @Override
+    public KinesisConnectorRecordProcessorFactory<String, String> getKinesisConnectorRecordProcessorFactory() {
+        return new KinesisConnectorRecordProcessorFactory<>(new RedshiftManifestPipeline(), config);
+    }
+
+    private static String REDSHIFT_CONFIG_FILE = "RedshiftManifest.properties";
+    private static String S3_CONFIG_FILE = "S3Manifest.properties";
+
+    /**
+     * Main method to run the Redshift manifest copy sample. Runs both the {@link S3ManifestExecutor} and
+     * {@link RedshiftManifestExecutor}
+     * 
+     * @param args
+     */
+    public static void main(String[] args) {
+        try {
+            Class.forName("org.postgresql.Driver");
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Could not load PostgreSQL driver");
+        }
+        // Spawn the S3Executor
+        KinesisConnectorExecutor<String, byte[]> s3ManifestExecutor = new S3ManifestExecutor(
+                S3_CONFIG_FILE);
+        Thread s3Thread = new Thread(s3ManifestExecutor);
+        s3Thread.start();
+
+        // Run the RedshiftExecutor
+        KinesisConnectorExecutor<String, String> redshiftExecutor = new RedshiftManifestExecutor(REDSHIFT_CONFIG_FILE);
+        redshiftExecutor.run();
+    }
+}

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/redshiftmanifest/RedshiftManifestPipeline.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/redshiftmanifest/RedshiftManifestPipeline.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.snowplowanalytics.snowplow.kinesis.redshiftmanifest;
+
+import com.amazonaws.services.kinesis.connectors.KinesisConnectorConfiguration;
+import com.amazonaws.services.kinesis.connectors.impl.AllPassFilter;
+import com.amazonaws.services.kinesis.connectors.impl.BasicMemoryBuffer;
+import com.amazonaws.services.kinesis.connectors.impl.StringToByteArrayTransformer;
+import com.amazonaws.services.kinesis.connectors.impl.StringToStringTransformer;
+import com.amazonaws.services.kinesis.connectors.interfaces.IBuffer;
+import com.amazonaws.services.kinesis.connectors.interfaces.IEmitter;
+import com.amazonaws.services.kinesis.connectors.interfaces.IFilter;
+import com.amazonaws.services.kinesis.connectors.interfaces.IKinesisConnectorPipeline;
+import com.amazonaws.services.kinesis.connectors.interfaces.ITransformer;
+import com.amazonaws.services.kinesis.connectors.redshift.RedshiftManifestEmitter;
+
+/**
+ * The Pipeline used by the {@link RedshiftManifestExecutor} in the Redshift manifest sample.
+ * Processes S3 file name records in String format. Uses:
+ * <ul>
+ * <li>{@link RedshiftManifestEmitter}</li>
+ * <li>{@link BasicMemoryBuffer}</li>
+ * <li>{@link StringToByteArrayTransformer}</li>
+ * <li>{@link AllPassFilter}</li>
+ * </ul>
+ */
+public class RedshiftManifestPipeline implements IKinesisConnectorPipeline<String, String> {
+
+    @Override
+    public IEmitter<String> getEmitter(KinesisConnectorConfiguration configuration) {
+        return new RedshiftManifestEmitter(configuration);
+    }
+
+    @Override
+    public IBuffer<String> getBuffer(KinesisConnectorConfiguration configuration) {
+        return new BasicMemoryBuffer<>(configuration);
+    }
+
+    @Override
+    public ITransformer<String, String> getTransformer(KinesisConnectorConfiguration configuration) {
+        return new StringToStringTransformer();
+    }
+
+    @Override
+    public IFilter<String> getFilter(KinesisConnectorConfiguration configuration) {
+        return new AllPassFilter<String>();
+    }
+
+}

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/redshiftmanifest/S3ManifestExecutor.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/redshiftmanifest/S3ManifestExecutor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.snowplowanalytics.snowplow.kinesis.redshiftmanifest;
+
+import com.snowplowanalytics.snowplow.kinesis.KinesisConnectorExecutor;
+
+import com.amazonaws.services.kinesis.connectors.KinesisConnectorRecordProcessorFactory;
+
+/**
+ * The executor used to emit files to S3 and then put the file names to a secondary Kinesis stream.
+ */
+public class S3ManifestExecutor extends KinesisConnectorExecutor<String, byte[]> {
+
+    /**
+     * Creates a new S3ManifestExecutor.
+     * 
+     * @param configFile
+     *            The name of the configuration file to look for on the classpath
+     */
+    public S3ManifestExecutor(String configFile) {
+        super(configFile);
+    }
+
+    @Override
+    public KinesisConnectorRecordProcessorFactory<String, byte[]> getKinesisConnectorRecordProcessorFactory() {
+        return new KinesisConnectorRecordProcessorFactory<>(new S3ManifestPipeline(), config);
+    }
+}

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/redshiftmanifest/S3ManifestPipeline.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/redshiftmanifest/S3ManifestPipeline.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.snowplowanalytics.snowplow.kinesis.redshiftmanifest;
+
+import com.amazonaws.services.kinesis.connectors.KinesisConnectorConfiguration;
+import com.amazonaws.services.kinesis.connectors.impl.AllPassFilter;
+import com.amazonaws.services.kinesis.connectors.impl.BasicMemoryBuffer;
+import com.amazonaws.services.kinesis.connectors.impl.StringToByteArrayTransformer;
+import com.amazonaws.services.kinesis.connectors.interfaces.IBuffer;
+import com.amazonaws.services.kinesis.connectors.interfaces.IEmitter;
+import com.amazonaws.services.kinesis.connectors.interfaces.IFilter;
+import com.amazonaws.services.kinesis.connectors.interfaces.IKinesisConnectorPipeline;
+import com.amazonaws.services.kinesis.connectors.interfaces.ITransformer;
+import com.amazonaws.services.kinesis.connectors.s3.S3ManifestEmitter;
+
+/**
+ * The Pipeline used by the {@link S3ManifestExecutor} in the Redshift manifest sample.
+ * Outputs S3 file name records in String format. Uses:
+ * <ul>
+ * <li>{@link S3ManifestEmitter}</li>
+ * <li>{@link BasicMemoryBuffer}</li>
+ * <li>{@link StringToByteArrayTransformer}</li>
+ * <li>{@link AllPassFilter}</li>
+ * </ul>
+ */
+public class S3ManifestPipeline implements IKinesisConnectorPipeline<String, byte[]> {
+
+    @Override
+    public IEmitter<byte[]> getEmitter(KinesisConnectorConfiguration configuration) {
+        return new S3ManifestEmitter(configuration);
+    }
+
+    @Override
+    public IBuffer<String> getBuffer(KinesisConnectorConfiguration configuration) {
+        return new BasicMemoryBuffer<String>(configuration);
+    }
+
+    @Override
+    public ITransformer<String, byte[]> getTransformer(KinesisConnectorConfiguration configuration) {
+        return new StringToByteArrayTransformer();
+    }
+
+    @Override
+    public IFilter<String> getFilter(KinesisConnectorConfiguration configuration) {
+        return new AllPassFilter<String>();
+    }
+
+}

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/utils/DynamoDBUtils.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/utils/DynamoDBUtils.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.snowplowanalytics.snowplow.kinesis.utils;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.amazonaws.services.autoscaling.model.ResourceInUseException;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
+import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
+import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
+import com.amazonaws.services.dynamodbv2.model.DescribeTableRequest;
+import com.amazonaws.services.dynamodbv2.model.DescribeTableResult;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.KeyType;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
+import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException;
+import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import com.amazonaws.services.dynamodbv2.model.TableDescription;
+import com.amazonaws.services.dynamodbv2.model.TableStatus;
+
+/**
+ * Utilities used to create and delete DynamoDB resources.
+ */
+public class DynamoDBUtils {
+
+    private static Log LOG = LogFactory.getLog(DynamoDBUtils.class);
+
+    /**
+     * Creates the DynamoDB table if it does not already exist and have the correct schema. Then it
+     * waits for the table to become active.
+     * 
+     * @param client
+     *        The {@link AmazonDynamoDBClient} with DynamoDB read and write privileges
+     * @param tableName
+     *        The DynamoDB table to create
+     * @param key
+     *        The DynamoDB table hashkey
+     * @param readCapacityUnits
+     *        Number of read capacity units for the DynamoDB table
+     * @param writeCapacityUnits
+     *        Number of write capacity units for the DynamoDB table
+     * @throws IllegalStateException
+     *         Table already exists and schema does not match
+     * @throws IllegalStateException
+     *         Table is already getting created
+     */
+    public static void createTable(AmazonDynamoDBClient client, String tableName, String key,
+            long readCapacityUnits, long writeCapacityUnits) {
+        if (tableExists(client, tableName)) {
+            if (tableHasCorrectSchema(client, tableName, key)) {
+                waitForActive(client, tableName);
+                return;
+            } else {
+                throw new IllegalStateException("Table already exists and schema does not match");
+            }
+
+        }
+        CreateTableRequest createTableRequest = new CreateTableRequest();
+        createTableRequest.setTableName(tableName);
+        createTableRequest.setKeySchema(Arrays.asList(new KeySchemaElement(key, KeyType.HASH)));
+        createTableRequest.setProvisionedThroughput(new ProvisionedThroughput(readCapacityUnits,
+                writeCapacityUnits));
+        createTableRequest.setAttributeDefinitions(Arrays.asList(new AttributeDefinition(key,
+                ScalarAttributeType.S)));
+        try {
+            client.createTable(createTableRequest);
+        } catch (ResourceInUseException e) {
+            throw new IllegalStateException("The table may already be getting created.", e);
+        }
+        LOG.info("Table " + tableName + " created");
+        waitForActive(client, tableName);
+    }
+
+    /**
+     * Helper method to wait until DynamoDB table becomes active.
+     * 
+     * @param client
+     *        The {@link AmazonDynamoDBClient} with DynamoDB read privileges
+     * @param tableName
+     *        The DynamoDB table to check the state of
+     * @throws IllegalStateException
+     *         Table is in the deleting state
+     * @throws IllegalStateException
+     *         Table did not become active before timeout
+     */
+    private static void waitForActive(AmazonDynamoDBClient client, String tableName) {
+        switch (getTableStatus(client, tableName)) {
+        case DELETING:
+            throw new IllegalStateException("Table " + tableName + " is in the DELETING state");
+        case ACTIVE:
+            LOG.info("Table " + tableName + " is ACTIVE");
+            return;
+        default:
+            long startTime = System.currentTimeMillis();
+            long endTime = startTime + (10 * 60 * 1000);
+            while (System.currentTimeMillis() < endTime) {
+                try {
+                    Thread.sleep(10 * 1000);
+                } catch (InterruptedException e) {
+                }
+                try {
+                    if (getTableStatus(client, tableName) == TableStatus.ACTIVE) {
+                        LOG.info("Table " + tableName + " is ACTIVE");
+                        return;
+                    }
+                } catch (ResourceNotFoundException e) {
+                    throw new IllegalStateException("Table " + tableName + " never went active");
+                }
+            }
+        }
+    }
+
+    /**
+     * Helper method to get the status of a DynamoDB table
+     * 
+     * @param client
+     *        The {@link AmazonDynamoDBClient} with DynamoDB read privileges
+     * @param tableName
+     *        The DynamoDB table to get the status of
+     * @return
+     */
+    private static TableStatus getTableStatus(AmazonDynamoDBClient client, String tableName) {
+        DescribeTableRequest describeTableRequest = new DescribeTableRequest();
+        describeTableRequest.setTableName(tableName);
+        DescribeTableResult describeTableResult = client.describeTable(describeTableRequest);
+        String status = describeTableResult.getTable().getTableStatus();
+        return TableStatus.fromValue(status);
+    }
+
+    /**
+     * Verifies if the table has the expected schema.
+     * @param client
+     *        The {@link AmazonDynamoDBClient} with DynamoDB read privileges
+     * @param tableName
+     *        The DynamoDB table to check
+     * @param key
+     *        The expected hashkey for the DynamoDB table
+     * @return true if the DynamoDB table exists and the expected hashkey matches the table schema,
+     *         otherwise return false
+     */
+    private static boolean tableHasCorrectSchema(AmazonDynamoDBClient client, String tableName, String key) {
+        DescribeTableRequest describeTableRequest = new DescribeTableRequest();
+        describeTableRequest.setTableName(tableName);
+        DescribeTableResult describeTableResult = client.describeTable(describeTableRequest);
+        TableDescription tableDescription = describeTableResult.getTable();
+        if (tableDescription.getAttributeDefinitions().size() != 1) {
+            LOG.error("The number of attribute definitions does not match the existing table.");
+            return false;
+        }
+        AttributeDefinition attributeDefinition = tableDescription.getAttributeDefinitions().get(0);
+        if (!attributeDefinition.getAttributeName().equals(key)
+                || !attributeDefinition.getAttributeType().equals(ScalarAttributeType.S.toString())) {
+            LOG.error("Attribute name or type does not match existing table.");
+            return false;
+        }
+        List<KeySchemaElement> KSEs = tableDescription.getKeySchema();
+        if (KSEs.size() != 1) {
+            LOG.error("The number of key schema elements does not match the existing table.");
+            return false;
+        }
+        KeySchemaElement kse = KSEs.get(0);
+        if (!kse.getAttributeName().equals(key) || !kse.getKeyType().equals(KeyType.HASH.toString())) {
+            LOG.error("The hash key does not match the existing table.");
+            return false;
+        }
+        return true;
+
+    }
+
+    /**
+     * Helper method to determine if a DynamoDB table exists.
+     * 
+     * @param client
+     *            The {@link AmazonDynamoDBClient} with DynamoDB read privileges
+     * @param tableName
+     *            The DynamoDB table to check for
+     * @return true if the DynamoDB table exists, otherwise return false
+     */
+    private static boolean tableExists(AmazonDynamoDBClient client, String tableName) {
+        DescribeTableRequest describeTableRequest = new DescribeTableRequest();
+        describeTableRequest.setTableName(tableName);
+        try {
+            client.describeTable(describeTableRequest);
+            return true;
+        } catch (ResourceNotFoundException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Deletes a DynamoDB table if it exists.
+     * 
+     * @param client
+     *            The {@link AmazonDynamoDBClient} with DynamoDB read and write privileges
+     * @param tableName
+     *            The DynamoDB table to delete
+     */
+    public static void deleteTable(AmazonDynamoDBClient client, String tableName) {
+        if (tableExists(client, tableName)) {
+            DeleteTableRequest deleteTableRequest = new DeleteTableRequest();
+            deleteTableRequest.setTableName(tableName);
+            client.deleteTable(deleteTableRequest);
+            LOG.info("Deleted table " + tableName);
+        } else {
+            LOG.warn("Table " + tableName + " does not exist");
+        }
+    }
+}

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/utils/KinesisUtils.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/utils/KinesisUtils.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.snowplowanalytics.snowplow.kinesis.utils;
+
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.kinesis.AmazonKinesisClient;
+import com.amazonaws.services.kinesis.connectors.KinesisConnectorConfiguration;
+import com.amazonaws.services.kinesis.model.CreateStreamRequest;
+import com.amazonaws.services.kinesis.model.DeleteStreamRequest;
+import com.amazonaws.services.kinesis.model.DescribeStreamRequest;
+import com.amazonaws.services.kinesis.model.ListStreamsRequest;
+import com.amazonaws.services.kinesis.model.ListStreamsResult;
+import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
+
+/**
+ * Utilities to create and delete Kinesis streams.
+ */
+public class KinesisUtils {
+
+    private static Log LOG = LogFactory.getLog(KinesisUtils.class);
+
+    /**
+     * Creates the Kinesis stream specified by config.KINESIS_INPUT_STREAM
+     * 
+     * @param config
+     *            The configuration with the specified input stream name and
+     *            {@link AWSCredentialsProvider}
+     * @param shardCount
+     *            The shard count to create the stream with
+     */
+    public static void createInputStream(KinesisConnectorConfiguration config, int shardCount) {
+        AmazonKinesisClient kinesisClient = new AmazonKinesisClient(config.AWS_CREDENTIALS_PROVIDER);
+        kinesisClient.setEndpoint(config.KINESIS_ENDPOINT);
+        createAndWaitForStreamToBecomeAvailable(kinesisClient, config.KINESIS_INPUT_STREAM, shardCount);
+    }
+
+    /**
+     * Creates the Kinesis stream specified by config.KINESIS_OUTPUT_STREAM.
+     * 
+     * @param config
+     *            The configuration with the specified output stream name and
+     *            {@link AWSCredentialsProvider}
+     * @param shardCount
+     *            The shard count to create the stream with
+     */
+    public static void createOutputStream(KinesisConnectorConfiguration config, int shardCount) {
+        AmazonKinesisClient kinesisClient = new AmazonKinesisClient(config.AWS_CREDENTIALS_PROVIDER);
+        kinesisClient.setEndpoint(config.KINESIS_ENDPOINT);
+        createAndWaitForStreamToBecomeAvailable(kinesisClient, config.KINESIS_OUTPUT_STREAM, shardCount);
+    }
+
+    /**
+     * Creates a Kinesis stream if it does not exist and waits for it to become available
+     * 
+     * @param kinesisClient
+     *            The {@link AmazonKinesisClient} with Kinesis read and write privileges
+     * @param streamName
+     *            The Kinesis stream name to create
+     * @param shardCount
+     *            The shard count to create the stream with
+     * @throws IllegalStateException
+     *             Invalid Kinesis stream state
+     * @throws IllegalStateException
+     *             Stream does not go active before the timeout
+     */
+    public static void createAndWaitForStreamToBecomeAvailable(AmazonKinesisClient kinesisClient,
+            String streamName, int shardCount) {
+        if (streamExists(kinesisClient, streamName)) {
+            String state = streamState(kinesisClient, streamName);
+            switch (state) {
+            case "DELETING":
+                long startTime = System.currentTimeMillis();
+                long endTime = startTime + 1000 * 120;
+                while (System.currentTimeMillis() < endTime && streamExists(kinesisClient, streamName)) {
+                    try {
+                        LOG.info("...Deleting Stream " + streamName + "...");
+                        Thread.sleep(1000 * 10);
+                    } catch (InterruptedException e) {
+                    }
+                }
+                if (streamExists(kinesisClient, streamName)) {
+                    LOG.error("KinesisUtils timed out waiting for stream " + streamName + " to delete");
+                    throw new IllegalStateException("KinesisUtils timed out waiting for stream " + streamName
+                            + " to delete");
+                }
+            case "ACTIVE":
+                LOG.info("Stream " + streamName + " is ACTIVE");
+                return;
+            case "CREATING":
+                break;
+            case "UPDATING":
+                LOG.info("Stream " + streamName + " is UPDATING");
+                return;
+            default:
+                throw new IllegalStateException("Illegal stream state: " + state);
+            }
+        } else {
+            CreateStreamRequest createStreamRequest = new CreateStreamRequest();
+            createStreamRequest.setStreamName(streamName);
+            createStreamRequest.setShardCount(shardCount);
+            kinesisClient.createStream(createStreamRequest);
+            LOG.info("Stream " + streamName + " created");
+        }
+        long startTime = System.currentTimeMillis();
+        long endTime = startTime + (10 * 60 * 1000);
+        while (System.currentTimeMillis() < endTime) {
+            try {
+                Thread.sleep(1000 * 10);
+            } catch (Exception e) {
+            }
+            try {
+                String streamStatus = streamState(kinesisClient, streamName);
+                if (streamStatus.equals("ACTIVE")) {
+                    LOG.info("Stream " + streamName + " is ACTIVE");
+                    return;
+                }
+            } catch (ResourceNotFoundException e) {
+                throw new IllegalStateException("Stream " + streamName + " never went active");
+            }
+        }
+    }
+
+    /**
+     * Helper method to determine if a Kinesis stream exists.
+     * 
+     * @param kinesisClient
+     *            The {@link AmazonKinesisClient} with Kinesis read privileges
+     * @param streamName
+     *            The Kinesis stream to check for
+     * @return true if the Kinesis stream exists, otherwise return false
+     */
+    private static boolean streamExists(AmazonKinesisClient kinesisClient, String streamName) {
+        DescribeStreamRequest describeStreamRequest = new DescribeStreamRequest();
+        describeStreamRequest.setStreamName(streamName);
+        try {
+            kinesisClient.describeStream(describeStreamRequest);
+            return true;
+        } catch (ResourceNotFoundException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Return the state of a Kinesis stream.
+     * 
+     * @param kinesisClient
+     *            The {@link AmazonKinesisClient} with Kinesis read privileges
+     * @param streamName
+     *            The Kinesis stream to get the state of
+     * @return String representation of the Stream state
+     */
+    private static String streamState(AmazonKinesisClient kinesisClient, String streamName) {
+        DescribeStreamRequest describeStreamRequest = new DescribeStreamRequest();
+        describeStreamRequest.setStreamName(streamName);
+        try {
+            return kinesisClient.describeStream(describeStreamRequest).getStreamDescription()
+                    .getStreamStatus();
+        } catch (AmazonServiceException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Gets a list of all Kinesis streams
+     * 
+     * @param kinesisClient
+     *            The {@link AmazonKinesisClient} with Kinesis read privileges
+     * @return list of Kinesis streams
+     */
+    public static List<String> listAllStreams(AmazonKinesisClient kinesisClient) {
+
+        ListStreamsRequest listStreamsRequest = new ListStreamsRequest();
+        listStreamsRequest.setLimit(10);
+        ListStreamsResult listStreamsResult = kinesisClient.listStreams(listStreamsRequest);
+        List<String> streamNames = listStreamsResult.getStreamNames();
+        while (listStreamsResult.isHasMoreStreams()) {
+            if (streamNames.size() > 0) {
+                listStreamsRequest.setExclusiveStartStreamName(streamNames.get(streamNames.size() - 1));
+            }
+
+            listStreamsResult = kinesisClient.listStreams(listStreamsRequest);
+            streamNames.addAll(listStreamsResult.getStreamNames());
+        }
+        return streamNames;
+    }
+
+    /**
+     * Deletes the input stream specified by config.KINESIS_INPUT_STREAM
+     * 
+     * @param config
+     *            The configuration containing the stream name and {@link AWSCredentialsProvider}
+     */
+    public static void deleteInputStream(KinesisConnectorConfiguration config) {
+        AmazonKinesisClient kinesisClient = new AmazonKinesisClient(config.AWS_CREDENTIALS_PROVIDER);
+        kinesisClient.setEndpoint(config.KINESIS_ENDPOINT);
+        deleteStream(kinesisClient, config.KINESIS_INPUT_STREAM);
+    }
+
+    /**
+     * Deletes the output stream specified by config.KINESIS_OUTPUT_STREAM
+     * 
+     * @param config
+     *            The configuration containing the stream name and {@link AWSCredentialsProvider}
+     */
+    public static void deleteOutputStream(KinesisConnectorConfiguration config) {
+        AmazonKinesisClient kinesisClient = new AmazonKinesisClient(config.AWS_CREDENTIALS_PROVIDER);
+        kinesisClient.setEndpoint(config.KINESIS_ENDPOINT);
+        deleteStream(kinesisClient, config.KINESIS_OUTPUT_STREAM);
+    }
+
+    /**
+     * Deletes a Kinesis stream if it exists.
+     * 
+     * @param kinesisClient
+     *            The {@link AmazonKinesisClient} with Kinesis read and write privileges
+     * @param streamName
+     *            The Kinesis stream to delete
+     */
+    public static void deleteStream(AmazonKinesisClient kinesisClient, String streamName) {
+        if (streamExists(kinesisClient, streamName)) {
+            DeleteStreamRequest deleteStreamRequest = new DeleteStreamRequest();
+            deleteStreamRequest.setStreamName(streamName);
+            kinesisClient.deleteStream(deleteStreamRequest);
+            LOG.info("Deleting stream " + streamName);
+        } else {
+            LOG.warn("Stream " + streamName + " does not exist");
+        }
+    }
+
+}

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/utils/RedshiftUtils.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/utils/RedshiftUtils.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.snowplowanalytics.snowplow.kinesis.utils;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.amazonaws.services.redshift.AmazonRedshiftClient;
+import com.amazonaws.services.redshift.model.Cluster;
+import com.amazonaws.services.redshift.model.ClusterNotFoundException;
+import com.amazonaws.services.redshift.model.CreateClusterRequest;
+import com.amazonaws.services.redshift.model.DeleteClusterRequest;
+import com.amazonaws.services.redshift.model.DescribeClustersRequest;
+import com.amazonaws.services.redshift.model.DescribeClustersResult;
+import com.amazonaws.services.redshift.model.Endpoint;
+
+public class RedshiftUtils {
+
+    private static Log LOG = LogFactory.getLog(RedshiftUtils.class);
+
+    /**
+     * Creates a Redshift cluster if it does not exist and waits for it to become active
+     * 
+     * @param client
+     *            The {@link AmazonRedshiftClient} with read and write permissions
+     * @param clusterIdentifier
+     *            The unique identifier of the Redshift cluster to create
+     * @param databaseName
+     *            The database name associated with the Redshift cluster
+     * @param masterUsername
+     *            The master username for the Redshift database
+     * @param masterUserPassword
+     *            The master password for the Redshift database
+     * @param clusterType
+     *            dw.hs1.xlarge or dw.hs1.8xlarge
+     * @param numberOfNodes
+     *            The number of nodes for the Redshift cluster
+     */
+    public static void createCluster(AmazonRedshiftClient client, String clusterIdentifier,
+            String databaseName, String masterUsername, String masterUserPassword, String clusterType,
+            int numberOfNodes) {
+        if (clusterExists(client, clusterIdentifier)) {
+            LOG.info("Cluster " + clusterIdentifier + " is available");
+            return;
+        }
+        CreateClusterRequest createClusterRequest = new CreateClusterRequest();
+        createClusterRequest.setClusterIdentifier(clusterIdentifier);
+        createClusterRequest.setMasterUsername(masterUsername);
+        createClusterRequest.setMasterUserPassword(masterUserPassword);
+        createClusterRequest.setNodeType(clusterType);
+        createClusterRequest.setNumberOfNodes(numberOfNodes);
+        createClusterRequest.setDBName(databaseName);
+        client.createCluster(createClusterRequest);
+        LOG.info("Created cluster " + clusterIdentifier);
+        String state = null;
+        while (!(state = clusterState(client, clusterIdentifier)).equals("available")) {
+            try {
+                Thread.sleep(10 * 1000);
+                LOG.info(clusterIdentifier + " is " + state + ". Waiting for cluster to become available.");
+            } catch (InterruptedException e) {
+
+            }
+        }
+        LOG.info("Cluster " + clusterIdentifier + " is available");
+    }
+
+    /**
+     * Gets the JDBC URL associated with an active Redshift cluster.
+     * 
+     * @param client
+     *            The {@link AmazonRedshiftClient} with read permissions
+     * @param clusterIdentifier
+     *            The unique Redshift cluster identifier
+     * @return JDBC URL for the Redshift cluster
+     */
+    public static String getClusterURL(AmazonRedshiftClient client, String clusterIdentifier) {
+        DescribeClustersRequest describeClustersRequest = new DescribeClustersRequest();
+        describeClustersRequest.setClusterIdentifier(clusterIdentifier);
+        DescribeClustersResult describeClustersResult = client.describeClusters(describeClustersRequest);
+        List<Cluster> clusters = describeClustersResult.getClusters();
+        if (!clusters.isEmpty()) {
+            return toJDBC(clusters.get(0).getEndpoint(), clusters.get(0).getDBName());
+        }
+        return null;
+    }
+
+    /**
+     * Helper method to convert a Redshift {@link Endpoint} and database name to JDBC connection
+     * String
+     * 
+     * @param endpoint
+     *            The Redshit Endpoint to convert to connection String
+     * @param databaseName
+     *            The database name for the Redshift cluster
+     * @return The JDBC connection String associated with the Endpoint and database name
+     */
+    private static String toJDBC(Endpoint endpoint, String databaseName) {
+        StringBuilder jdbc = new StringBuilder();
+        jdbc.append("jdbc:postgresql://");
+        jdbc.append(endpoint.getAddress());
+        jdbc.append(":" + endpoint.getPort());
+        jdbc.append("/" + databaseName);
+        return jdbc.toString();
+    }
+
+    /**
+     * Delete the Redshift cluster if it exists
+     * 
+     * @param client
+     *            The {@link AmazonRedshiftClient} with read and write permissions
+     * @param clusterIdentifier
+     *            The Redshift cluster delete
+     * @param skipFinalClusterSnapshot
+     *            Should Redshift skip the final cluster snapshot?
+     */
+    public static void deleteCluster(AmazonRedshiftClient client, String clusterIdentifier,
+            boolean skipFinalClusterSnapshot) {
+        if (clusterExists(client, clusterIdentifier)) {
+            DeleteClusterRequest deleteClusterRequest = new DeleteClusterRequest();
+            deleteClusterRequest.setClusterIdentifier(clusterIdentifier);
+            deleteClusterRequest.setSkipFinalClusterSnapshot(skipFinalClusterSnapshot);
+            client.deleteCluster(deleteClusterRequest);
+        } else {
+            LOG.warn("Redshift cluster " + clusterIdentifier + " does not exist");
+        }
+    }
+
+    /**
+     * Helper method to determine if a Redshift cluster exists
+     * 
+     * @param client
+     *            The {@link AmazonRedshiftClient} with read permissions
+     * @param clusterIdentifier
+     *            The Redshift cluster to check
+     * @return true if the Redshift cluster exists, otherwise return false
+     */
+    private static boolean clusterExists(AmazonRedshiftClient client, String clusterIdentifier) {
+        DescribeClustersRequest describeClustersRequest = new DescribeClustersRequest();
+        describeClustersRequest.setClusterIdentifier(clusterIdentifier);
+        try {
+            client.describeClusters(describeClustersRequest);
+            return true;
+        } catch (ClusterNotFoundException e) {
+            return false;
+        }
+
+    }
+
+    /**
+     * Helper method to determine the Redshift cluster state
+     * 
+     * @param client
+     *            The {@link AmazonRedshiftClient} with read permissions
+     * @param clusterIdentifier
+     *            The Redshift cluster to get the state of
+     * @return The String representation of the Redshift cluster state
+     */
+    public static String clusterState(AmazonRedshiftClient client, String clusterIdentifier) {
+        DescribeClustersRequest describeClustersRequest = new DescribeClustersRequest();
+        describeClustersRequest.setClusterIdentifier(clusterIdentifier);
+        List<Cluster> clusters = client.describeClusters(describeClustersRequest).getClusters();
+        if (clusters.size() == 1) {
+            return clusters.get(0).getClusterStatus();
+        }
+        throw new ClusterNotFoundException(clusterIdentifier);
+
+    }
+
+    /**
+     * Helper method to create a Redshift table
+     * 
+     * @param redshiftURL
+     *            The JDBC URL of the Redshift database
+     * @param loginProperties
+     *            A properties file containing the authentication credentials for the database
+     * @param tableName
+     *            The table to create
+     * @param fields
+     *            A list of column specifications that will be comma separated in the create table
+     *            statement
+     * @throws SQLException
+     *             Table creation failed
+     */
+    public static void createRedshiftTable(String redshiftURL, Properties loginProperties, String tableName,
+            List<String> fields) throws SQLException {
+        Connection conn = DriverManager.getConnection(redshiftURL, loginProperties);
+        Statement stmt = conn.createStatement();
+        stmt.execute("CREATE TABLE " + tableName + " " + toSQLFields(fields) + ";");
+        stmt.close();
+        conn.close();
+    }
+
+    /**
+     * Helper method to build a field String for creating the table in the format (field1, field2,
+     * ...)
+     * 
+     * @param fields
+     * @return String in the format (field1, field2, ...)
+     */
+    private static String toSQLFields(List<String> fields) {
+        StringBuilder s = new StringBuilder();
+        s.append("(");
+        for (String field : fields) {
+            s.append(field);
+            s.append(",");
+        }
+        s.replace(s.length() - 1, s.length(), "");
+        s.append(")");
+        return s.toString();
+    }
+
+    /**
+     * Helper method to determine if a table exists in the Redshift database
+     * 
+     * @param loginProperties
+     *            A properties file containing the authentication credentials for the database
+     * @param redshiftURL
+     *            The JDBC URL of the Redshift database
+     * @param tableName
+     *            The table to check existence of
+     * @return true if connection to the database is successful and the table exists, otherwise
+     *         false
+     */
+    public static boolean tableExists(Properties loginProperties, String redshiftURL, String tableName) {
+        Connection conn = null;
+        try {
+            conn = DriverManager.getConnection(redshiftURL, loginProperties);
+
+            Statement stmt = conn.createStatement();
+            stmt.executeQuery("SELECT * FROM " + tableName + " LIMIT 1;");
+            stmt.close();
+            conn.close();
+            return true;
+        } catch (SQLException e) {
+            LOG.error(e);
+            try {
+                conn.close();
+            } catch (Exception e1) {
+            }
+            return false;
+        }
+    }
+
+}

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/utils/S3Utils.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/utils/S3Utils.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.snowplowanalytics.snowplow.kinesis.utils;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CreateBucketRequest;
+import com.amazonaws.services.s3.model.DeleteBucketRequest;
+import com.amazonaws.services.s3.model.Region;
+
+public class S3Utils {
+
+    private static Log LOG = LogFactory.getLog(S3Utils.class);
+
+    /**
+     * Create a S3 bucket if it does not exist.
+     * 
+     * @param client
+     *            The {@link AmazonS3Client} with read and write permissions
+     * @param bucketName
+     *            The bucket to create
+     * @throws IllegalStateException
+     *             The bucket is not created before timeout occurs
+     */
+    public static void createBucket(AmazonS3Client client, String bucketName) {
+        if (!bucketExists(client, bucketName)) {
+            CreateBucketRequest createBucketRequest = new CreateBucketRequest(bucketName);
+            createBucketRequest.setRegion(Region.US_Standard.toString());
+            client.createBucket(createBucketRequest);
+        }
+        long startTime = System.currentTimeMillis();
+        long endTime = startTime + 60 * 1000;
+        while (!bucketExists(client, bucketName) && endTime > System.currentTimeMillis()) {
+            try {
+                LOG.info("Waiting for S3 to create bucket " + bucketName);
+                Thread.sleep(1000 * 10);
+            } catch (InterruptedException e) {
+            }
+        }
+        if (!bucketExists(client, bucketName)) {
+            throw new IllegalStateException("Could not create bucket " + bucketName);
+        }
+        LOG.info("Created S3 bucket " + bucketName);
+    }
+
+    /**
+     * 
+     * @param client
+     *            The {@link AmazonS3Client} with read permissions
+     * @param bucketName
+     *            Check if this bucket exists
+     * @return true if the S3 bucket exists, otherwise return false
+     */
+    private static boolean bucketExists(AmazonS3Client client, String bucketName) {
+        return client.doesBucketExist(bucketName);
+    }
+
+    /**
+     * Deletes a S3 bucket if it exists.
+     * @param client The {@link AmazonS3Client} with read and write permissions
+     * @param bucketName The S3 bucket to delete
+     */
+    public static void deleteBucket(AmazonS3Client client, String bucketName) {
+        if (bucketExists(client, bucketName)) {
+            DeleteBucketRequest deleteBucketRequest = new DeleteBucketRequest(bucketName);
+            client.deleteBucket(deleteBucketRequest);
+            LOG.info("Deleted bucket " + bucketName);
+        } else {
+            LOG.warn("Bucket " + bucketName + " does not exist");
+        }
+    }
+}

--- a/4-storage/kinesis-redshift-sink/src/main/resources/RedshiftBasic.properties
+++ b/4-storage/kinesis-redshift-sink/src/main/resources/RedshiftBasic.properties
@@ -1,0 +1,48 @@
+# KinesisConnector Application Settings
+appName = kinesisToRedshiftBasic
+retryLimit = 3
+# 1MB = 1024*1024 = 1048756
+bufferSizeByteLimit = 1048576 
+bufferRecordCountLimit = 25
+
+# Redshift parameters for KinesisConnector
+redshiftDataTable = kinesisBasicTable
+redshiftEndpoint = https\://redshift.us-east-1.amazonaws.com
+redshiftUsername = USERNAME
+redshiftPassword = PASSWORD
+# URL is optional if automatically creating the cluster
+redshiftURL = URL
+redshiftDataDelimiter = |
+
+
+# Optional Redshift parameters for automatically creating the cluster
+createRedshiftCluster = false
+redshiftClusterIdentifier = kinesisCluster
+redshiftDatabaseName = kinesisDatabase
+# dw.hs1.xlarge or dw.hs1.8xlarge
+redshiftClusterType = dw.hs1.xlarge
+redshiftNumberOfNodes = 2
+
+# Optional Redshift parameters for automatically creating the data table
+createRedshiftDataTable = false
+
+# S3 parameters for KinesisConnector
+s3Bucket = kinesis-bucket
+s3Endpoint = https\://s3.amazonaws.com
+
+# Optional S3 parameters for automatically creating the bucket
+createS3Bucket = false
+
+# Kinesis parameters for KinesisConnector
+kinesisEndpoint = https\://kinesis.us-east-1.amazonaws.com
+kinesisInputStream = redshiftStream
+
+# Optional Kinesis parameters for automatically creating the stream
+createKinesisInputStream = false
+createKinesisOutputStream = false
+kinesisInputStreamShardCount = 2
+kinesisOutputStreamShardCount = 2
+
+# Specifies the input file from which the StreamSource will read records
+createStreamSource = true
+inputStreamFile = users.txt

--- a/4-storage/kinesis-redshift-sink/src/main/resources/RedshiftManifest.properties
+++ b/4-storage/kinesis-redshift-sink/src/main/resources/RedshiftManifest.properties
@@ -1,0 +1,47 @@
+# Kinesis Connector Application Settings
+appName = kinesisToRedshiftBasic
+retryLimit = 3
+bufferSizeByteLimit = 1024 
+bufferRecordCountLimit = 8
+
+# Redshift parameters for Kinesis Connector
+redshiftDataTable = kinesisData
+redshiftFileTable = kinesisFiles
+redshiftEndpoint = https\://redshift.us-east-1.amazonaws.com
+redshiftUsername = USERNAME
+redshiftPassword = PASSWORD
+# URL is optional if automatically creating the cluster
+redshiftURL = URL
+redshiftDataDelimiter = |
+
+
+# Optional Redshift parameters for automatically creating the cluster
+createRedshiftCluster = false
+redshiftClusterIdentifier = kinesisCluster
+redshiftDatabaseName = kinesisDatabase
+# dw.hs1.xlarge or dw.hs1.8xlargeﬂ
+redshiftClusterType = dw.hs1.xlarge
+redshiftNumberOfNodes = 2
+
+# Optional Redshift parameters for automatically creating the data table
+createRedshiftTable = false
+
+# Optional Redshift parameters for automatically creating the file table
+createRedshiftFileTable = false
+
+# S3 parameters for KinesisConnector
+s3Bucket = kinesis-bucket
+s3Endpoint = https\://s3.amazonaws.com
+
+# Optional S3 parameters for automatically creating the bucket
+createS3Bucket = false
+
+# Kinesis parameters for KinesisConnector
+kinesisEndpoint = https\://kinesis.us-east-1.amazonaws.com
+kinesisInputStream = secondaryManifestStream
+
+# Optional Kinesis parameters for automatically creating the stream
+createKinesisInputStream = false
+createKinesisOutputStream = false
+kinesisInputStreamShardCount = 2
+kinesisOutputStreamShardCount = 2

--- a/4-storage/kinesis-redshift-sink/src/main/resources/S3Manifest.properties
+++ b/4-storage/kinesis-redshift-sink/src/main/resources/S3Manifest.properties
@@ -1,0 +1,28 @@
+# KinesisConnector Application Settings
+appName = kinesisToS3
+retryLimit = 3
+# 1MB = 1024*1024 = 1048756
+bufferSizeByteLimit = 1048576 
+bufferRecordCountLimit = 25
+
+# S3 parameters for KinesisConnector
+s3Bucket = kinesis-bucket
+s3Endpoint = https\://s3.amazonaws.com
+
+# Optional S3 parameters for automatically creating the bucket
+createS3Bucket = false
+
+# Kinesis parameters for KinesisConnector
+kinesisEndpoint = https\://kinesis.us-east-1.amazonaws.com
+kinesisInputStream = primaryManifestStream
+kinesisOutputStream = secondaryManifestStream
+
+# Optional Kinesis parameters for automatically creating the stream
+createKinesisInputStream = false
+createKinesisOutputStream = false
+kinesisInputStreamShardCount = 2
+kinesisOutputStreamShardCount = 2
+
+# Specifies file the StreamSource will read records from
+createStreamSource = true
+inputStreamFile = users.txt


### PR DESCRIPTION
Java Kinesis Redshift Sink processes Snowplow events, in the Canonical Output format, from an input Amazon Kinesis stream and stores them into a Redshift database.

This work derives from the sample Kinesis Applications and connectors library included in the [amazon-kinesis-connectors](https://github.com/awslabs/amazon-kinesis-connectors) project. This is a joint work by @bugant and @potomak.

See also https://github.com/snowplow/snowplow/pull/546 for a Kinesi S3 Sink in Scala.