### PR TITLE
StorageLoader: add missing targetUrl field to ad_impression JSON Path file

### DIFF
--- a/4-storage/redshift-storage/jsonpaths/com.snowplowanalytics.snowplow/ad_impression_1.json
+++ b/4-storage/redshift-storage/jsonpaths/com.snowplowanalytics.snowplow/ad_impression_1.json
@@ -17,6 +17,7 @@
     "$.data.bannerId",
     "$.data.campaignId",
     "$.data.advertiserId",
+    "$.data.targetUrl",
     "$.data.costModel",
     "$.data.cost"
     ]


### PR DESCRIPTION
Storage loader's sql assets have targetUrl but not the json schema
