### PR TITLE
Trackers: fix broken git submodule links

### DIFF
--- a/1-trackers/README.md
+++ b/1-trackers/README.md
@@ -29,13 +29,13 @@ For other trackers (e.g. iOS, Android) and their approximate timelines, please s
 
 [architecture-image]: https://d3i6fms1cm1j0i.cloudfront.net/github-wiki/images/1-trackers.png
 [collectors]: https://github.com/snowplow/snowplow/tree/master/2-collectors
-[t1]: https://github.com/snowplow/javascript-tracker
+[t1]: https://github.com/snowplow/snowplow-javascript-tracker
 [t2]: ./no-js-tracker/
-[t3]: https://github.com/snowplow/python-tracker
-[t4]: https://github.com/snowplow/ruby-tracker
-[t5]: https://github.com/snowplow/java-tracker
-[t6]: https://github.com/snowplow/arduino-tracker
-[t7]: https://github.com/snowplow/lua-tracker
+[t3]: https://github.com/snowplow/snowplow-python-tracker
+[t4]: https://github.com/snowplow/snowplow-ruby-tracker
+[t5]: https://github.com/snowplow/snowplow-java-tracker
+[t6]: https://github.com/snowplow/snowplow-arduino-tracker
+[t7]: https://github.com/snowplow/snowplow-lua-tracker
 [setup]: https://github.com/snowplow/snowplow/wiki/Setting-up-a-Tracker
 [tech-docs]: https://github.com/snowplow/snowplow/wiki/trackers
 [wiki]: https://github.com/snowplow/snowplow/wiki


### PR DESCRIPTION
I'm new to this repo but am assuming that these links should have been pointing to their git repositories.  Previously they were broken, I'm assuming you recently refactored some of this.
