### PR TITLE
@alexanderdean @pkallos => Make PR #689 production ready

### DIFF
--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/KinesisConnectorExecutor.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/KinesisConnectorExecutor.java
@@ -250,30 +250,139 @@ public abstract class KinesisConnectorExecutor<T,U> extends KinesisConnectorExec
      * Helper method to build the data table
      * 
      * @return Fields for the data table
+     * Supported data types: http://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html
+     * Snowplow cannonical event model code: https://github.com/snowplow/snowplow/blob/c4189163f71ec99215485eff72398ca7bfc3556d/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/outputs/EnrichedEvent.scala#L39
+     * Snowplow cannonical event model descriptions/types: https://github.com/snowplow/snowplow/wiki/Canonical-event-model
      *
      * @deprecated
      */
     @Deprecated
     private static List<String> getKinesisMessageModelFields() {
         List<String> fields = new ArrayList<String>();
-        fields.add("userid integer not null distkey sortkey");
-        fields.add("username char(8)");
-        fields.add("firstname varchar(30)");
-        fields.add("lastname varchar(30)");
-        fields.add("city varchar(30)");
-        fields.add("state char(2)");
-        fields.add("email varchar(100)");
-        fields.add("phone char(14)");
-        fields.add("likesports boolean");
-        fields.add("liketheatre boolean");
-        fields.add("likeconcerts boolean");
-        fields.add("likejazz boolean");
-        fields.add("likeclassical boolean");
-        fields.add("likeopera boolean");
-        fields.add("likerock boolean");
-        fields.add("likevegas boolean");
-        fields.add("likebroadway boolean");
-        fields.add("likemusicals boolean");
+        // The application (site, game, app etc) this event belongs to, and the tracker platform
+        fields.add("app_id varchar(30)"); // Ex: "force"
+        fields.add("platform varchar(30)"); // Ex: "web"
+        // Date/time
+        fields.add("etl_tstamp timestamp"); // Ex: "2014-09-18 15:50:33.333"
+        fields.add("collector_tstamp timestamp"); // Ex: "2014-09-18 15:50:15.156"
+        // Transaction (i.e. this logging event)
+        fields.add("event varchar(30)"); // Ex: "struct"
+        fields.add("name_org varchar(30)"); // Ex: "com.snowplowanalytics"
+        fields.add("event_id char(36)"); // Ex: "4b25d258-2831-4fdc-8125-43ebf2d5b12b"
+        fields.add("txn_id integer"); // Ex: "644474"
+        // Versioning
+        fields.add("v_tracker varchar(30)"); // Ex: "js-2.0.0"
+        fields.add("v_collector varchar(30)"); // Ex: "ssc-0.1.0-kinesis"
+        fields.add("v_etl varchar(30)"); // Ex: "kinesis-0.1.0-common-0.2.0"
+        // User and visit
+        fields.add("user_id char(24)"); // Ex: "541afb78636172313c000000"
+        fields.add("user_ipaddress varchar(30)"); // Ex: "108.27.195.x"
+        fields.add("user_fingerprint integer"); // Ex: "4135552504"
+        fields.add("domain_userid char(16)"); // Ex: "7940bcc0dffc1363"
+        fields.add("domain_sessionidx integer"); // Ex: "1"
+        fields.add("network_userid char(36)"); // Ex: ""
+        // Location
+        fields.add("geo_country char(2)"); // Ex: "US"
+        fields.add("geo_region char(2)"); // Ex: "NY"
+        fields.add("geo_city varchar(120)"); // Ex: "New York"
+        fields.add("geo_zipcode varchar(30)"); // Ex: "10023"
+        fields.add("geo_latitude varchar(30)"); // Ex: "40.7769"
+        fields.add("geo_longitude varchar(30)"); // Ex: "-73.9813"
+        fields.add("geo_region_name varchar(120)"); // Ex: ""
+        // Other IP lookups SKIPPED
+        // Page SKIPPED
+        // Page URL components
+        fields.add("page_urlscheme varchar(8)"); // Ex: "http"
+        fields.add("page_urlhost varchar(120)"); // Ex: "localhost"
+        fields.add("page_urlport integer"); // Ex: "5000"
+        fields.add("page_urlpath varchar(2000)"); // Ex: "/artwork/ben-jones-cubes"
+        fields.add("page_urlquery varchar(2000)"); // Ex: ""
+        fields.add("page_urlfragment varchar(2000)"); // Ex: ""
+        // Referrer URL components
+        fields.add("refr_urlscheme varchar(8)"); // Ex: "http"
+        fields.add("refr_urlhost varchar(120)"); // Ex: "localhost"
+        fields.add("refr_urlport integer"); // Ex: "5000"
+        fields.add("refr_urlpath varchar(2000)"); // Ex: "/"
+        fields.add("refr_urlquery varchar(2000)"); // Ex: ""
+        fields.add("refr_urlfragment varchar(2000)"); // Ex: ""
+        // Referrer details
+        fields.add("refr_medium varchar(30)"); // Ex: "internal"
+        fields.add("refr_source varchar(120)"); // Ex: ""
+        fields.add("refr_term varchar(260)"); // Ex: ""
+        // Marketing
+        fields.add("mkt_medium varchar(120)"); // Ex: 'social'
+        fields.add("mkt_source varchar(120)"); // Ex: 'Facebook'
+        fields.add("mkt_term varchar(120)"); // Ex: 'new age tarot decks'
+        fields.add("mkt_content varchar(120)"); // Ex: 13894723
+        fields.add("mkt_campaign varchar(120)"); // Ex: 'diageo-123'
+        // Custom Contexts SKIPPED
+        // Structured Event
+        fields.add("se_category varchar(30)"); // Ex: "inquiry"
+        fields.add("se_action varchar(30)"); // Ex: "submit"
+        fields.add("se_label varchar(120)"); // Ex: "541afb78636172313c000000"
+        fields.add("se_property varchar(30)"); // Ex: "artwork"
+        fields.add("se_value real"); // Ex: "0.0"
+        // Unstructured Event SKIPPED
+        // Ecommerce transaction (from querystring)
+        fields.add("tr_orderid varchar(30)"); //  Ex: '#134'
+        fields.add("tr_affiliation varchar(30)"); //  Ex: 'web'
+        fields.add("tr_total real"); //  Ex: 12.99
+        fields.add("tr_tax real"); //  Ex: 3.00
+        fields.add("tr_shipping real"); //  Ex: 0.00
+        fields.add("tr_city varchar(30)"); //  Ex: 'London'
+        fields.add("tr_state varchar(30)"); //  Ex: 'Washington'
+        fields.add("tr_country varchar(30)"); //  Ex: 'France'
+        // Ecommerce transaction item (from querystring)
+        fields.add("ti_orderid varchar(30)"); // Ex: '#134'
+        fields.add("ti_sku varchar(30)"); // Ex: 'pbz00123'
+        fields.add("ti_name varchar(30)"); // Ex: Cone 'pendulum'
+        fields.add("ti_category varchar(30)"); // Ex: 'New Age'
+        fields.add("ti_price varchar(30)"); // Ex: '9.99'
+        fields.add("ti_quantity varchar(30)"); // Ex: '2'
+        // Page Pings
+        fields.add("pp_xoffset_min integer"); // Ex: 0
+        fields.add("pp_xoffset_max integer"); // Ex: 100
+        fields.add("pp_yoffset_min integer"); // Ex: 0
+        fields.add("pp_yoffset_max integer"); // Ex: 200
+        // User Agent
+        fields.add("useragent varchar(2000)"); // Ex: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.120 Safari/537.36"
+        // Browser (from user-agent)
+        fields.add("br_name varchar(120)"); // Ex: "Chrome"
+        fields.add("br_family varchar(120)"); // Ex: "Chrome"
+        fields.add("br_version varchar(120)"); // Ex: "37.0.2062.120"
+        fields.add("br_type varchar(120)"); // Ex: "Browser"
+        fields.add("br_renderengine varchar(120)"); // Ex: "WEBKIT"
+        // Browser (from querystring)
+        fields.add("br_lang varchar(30)"); // Ex: "en-US"
+        // Individual feature fields for non-Hive targets (e.g. Infobright)
+        fields.add("br_features_pdf boolean"); // Ex: "1"
+        fields.add("br_features_flash boolean"); // Ex: "1"
+        fields.add("br_features_java boolean"); // Ex: "1"
+        fields.add("br_features_director boolean"); // Ex: "0"
+        fields.add("br_features_quicktime boolean"); // Ex: "1"
+        fields.add("br_features_realplayer boolean"); // Ex: "0"
+        fields.add("br_features_windowsmedia boolean"); // Ex: "0"
+        fields.add("br_features_gears boolean"); // Ex: "0"
+        fields.add("br_features_silverlight boolean"); // Ex: "1"
+        fields.add("br_cookies boolean"); // Ex: "1"
+        fields.add("br_colordepth integer"); // Ex: "24"
+        fields.add("br_viewwidth integer"); // Ex: "1680"
+        fields.add("br_viewheight integer"); // Ex: "517"
+        // OS (from user-agent)
+        fields.add("os_name varchar(120)"); // Ex: "Mac OS X"
+        fields.add("os_family varchar(120)"); // Ex: "Mac OS X"
+        fields.add("os_manufacturer varchar(120)"); // Ex: "Apple Inc."
+        fields.add("os_timezone varchar(120)"); // Ex: "America/New_York"
+        // Device/Hardware (from user-agent)
+        fields.add("dvce_type varchar(30)"); // Ex: "Computer"
+        fields.add("dvce_ismobile boolean"); // Ex: "0"
+        // Device (from querystring)
+        fields.add("dvce_screenwidth integer"); // Ex: "1680"
+        fields.add("dvce_screenheight integer"); // Ex: "1050"
+        // Document
+        fields.add("doc_charset varchar(30)"); // Ex: "UTF-8"
+        fields.add("doc_width integer"); // Ex: "1680"
+        fields.add("doc_height integer"); // Ex: "1293"
         return fields;
     }
 

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/KinesisConnectorExecutor.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/KinesisConnectorExecutor.java
@@ -288,9 +288,9 @@ public abstract class KinesisConnectorExecutor<T,U> extends KinesisConnectorExec
         fields.add("geo_zipcode varchar(30)"); // Ex: "10023"
         fields.add("geo_latitude varchar(30)"); // Ex: "40.7769"
         fields.add("geo_longitude varchar(30)"); // Ex: "-73.9813"
-        fields.add("geo_region_name varchar(120)"); // Ex: ""
         // Other IP lookups SKIPPED
-        // Page SKIPPED
+        // Page
+        fields.add("page_title varchar(2000)"); // Ex: 'Using ChartIO to visualize and interrogate Snowplow data - Snowplow Analytics'
         // Page URL components
         fields.add("page_urlscheme varchar(8)"); // Ex: "http"
         fields.add("page_urlhost varchar(120)"); // Ex: "localhost"

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/KinesisConnectorExecutor.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/KinesisConnectorExecutor.java
@@ -269,7 +269,7 @@ public abstract class KinesisConnectorExecutor<T,U> extends KinesisConnectorExec
         fields.add("event varchar(30)"); // Ex: "struct"
         fields.add("name_org varchar(30)"); // Ex: "com.snowplowanalytics"
         fields.add("event_id char(36)"); // Ex: "4b25d258-2831-4fdc-8125-43ebf2d5b12b"
-        fields.add("txn_id integer"); // Ex: "644474"
+        fields.add("txn_id bigint"); // Ex: "644474"
         // Versioning
         fields.add("v_tracker varchar(30)"); // Ex: "js-2.0.0"
         fields.add("v_collector varchar(30)"); // Ex: "ssc-0.1.0-kinesis"
@@ -277,9 +277,9 @@ public abstract class KinesisConnectorExecutor<T,U> extends KinesisConnectorExec
         // User and visit
         fields.add("user_id char(24)"); // Ex: "541afb78636172313c000000"
         fields.add("user_ipaddress varchar(30)"); // Ex: "108.27.195.x"
-        fields.add("user_fingerprint integer"); // Ex: "4135552504"
+        fields.add("user_fingerprint bigint"); // Ex: "4135552504"
         fields.add("domain_userid char(16)"); // Ex: "7940bcc0dffc1363"
-        fields.add("domain_sessionidx integer"); // Ex: "1"
+        fields.add("domain_sessionidx bigint"); // Ex: "1"
         fields.add("network_userid char(36)"); // Ex: ""
         // Location
         fields.add("geo_country char(2)"); // Ex: "US"

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/MyRedshiftBasicEmitter.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/MyRedshiftBasicEmitter.java
@@ -1,3 +1,6 @@
+// Coppied from amazon's library here: https://github.com/awslabs/amazon-kinesis-connectors/blob/49e674efeae04734abe6f7385d7037788ea70145/src/main/java/com/amazonaws/services/kinesis/connectors/redshift/RedshiftBasicEmitter.java#L51
+
+
 /*
  * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/MyRedshiftBasicEmitter.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/MyRedshiftBasicEmitter.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.snowplowanalytics.snowplow.kinesis;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.amazonaws.services.kinesis.connectors.KinesisConnectorConfiguration;
+import com.amazonaws.services.kinesis.connectors.UnmodifiableBuffer;
+import com.snowplowanalytics.snowplow.kinesis.MyS3Emitter;
+
+/**
+ * This class is an implementation of IEmitter that emits records into Redshift one by one. It
+ * utilizes the Redshift copy command on each file by first inserting records into S3 and then
+ * performing the Redshift copy command. S3 insertion is done by extending the S3 emitter.
+ * <p>
+ * * This class requires the configuration of an S3 bucket and endpoint, as well as the following
+ * Redshift items:
+ * <ul>
+ * <li>Redshift URL</li>
+ * <li>username and password</li>
+ * <li>data table and key column (data table stores items from the manifest copy)</li>
+ * <li>file table and key column (file table is used to store file names to prevent duplicate
+ * entries)</li>
+ * <li>the delimiter used for string parsing when inserting entries into Redshift</li>
+ * <br>
+ * NOTE: The S3 bucket and the Redshift cluster need to be in the same region.
+ */
+public class MyRedshiftBasicEmitter extends MyS3Emitter {
+    private static final Log LOG = LogFactory.getLog(MyRedshiftBasicEmitter.class);
+    private final String s3bucket;
+    private final String redshiftTable;
+    private final String redshiftURL;
+    private final char redshiftDelimiter;
+    private final Properties loginProperties;
+    private final String accessKey;
+    private final String secretKey;
+
+    public MyRedshiftBasicEmitter(KinesisConnectorConfiguration configuration) {
+        super(configuration);
+        s3bucket = configuration.S3_BUCKET;
+        redshiftTable = configuration.REDSHIFT_DATA_TABLE;
+        redshiftDelimiter = configuration.REDSHIFT_DATA_DELIMITER;
+        redshiftURL = configuration.REDSHIFT_URL;
+        loginProperties = new Properties();
+        loginProperties.setProperty("user", configuration.REDSHIFT_USERNAME);
+        loginProperties.setProperty("password", configuration.REDSHIFT_PASSWORD);
+        accessKey = configuration.AWS_CREDENTIALS_PROVIDER.getCredentials().getAWSAccessKeyId();
+        secretKey = configuration.AWS_CREDENTIALS_PROVIDER.getCredentials().getAWSSecretKey();
+    }
+
+    @Override
+    public List<byte[]> emit(final UnmodifiableBuffer<byte[]> buffer) throws IOException {
+        List<byte[]> failed = super.emit(buffer);
+        if (!failed.isEmpty()) {
+            return buffer.getRecords();
+        }
+        Connection conn = null;
+        try {
+            conn = DriverManager.getConnection(redshiftURL, loginProperties);
+            String s3File = getS3FileName(buffer.getFirstSequenceNumber(), buffer.getLastSequenceNumber());
+            executeStatement(generateCopyStatement(s3File), conn);
+            LOG.info("Successfully copied " + getNumberOfCopiedRecords(conn)
+                    + " records to Redshift from file s3://" + s3Bucket + "/" + s3File);
+            closeConnection(conn);
+            return Collections.emptyList();
+        } catch (IOException | SQLException e) {
+            LOG.error(e);
+            closeConnection(conn);
+            return buffer.getRecords();
+        }
+    }
+
+    @Override
+    public void fail(List<byte[]> records) {
+        super.fail(records);
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+    }
+
+    private void closeConnection(Connection conn) {
+        try {
+            conn.close();
+        } catch (Exception e) {
+            LOG.error(e);
+        }
+    }
+
+    private String generateCopyStatement(String s3File) {
+        StringBuilder exec = new StringBuilder();
+        exec.append("COPY " + redshiftTable + " ");
+        exec.append("FROM 's3://" + s3bucket + "/" + s3File + "' ");
+        exec.append("CREDENTIALS 'aws_access_key_id=" + accessKey);
+        exec.append(";aws_secret_access_key=" + secretKey + "' ");
+        exec.append("DELIMITER '" + redshiftDelimiter + "'");
+        exec.append(";");
+        return exec.toString();
+    }
+
+    private void executeStatement(String statement, Connection conn) throws IOException {
+        try {
+            Statement stmt = conn.createStatement();
+            stmt.execute(statement);
+            stmt.close();
+            return;
+        } catch (SQLException e) {
+            LOG.error(e);
+            throw new IOException(e);
+        }
+
+    }
+
+    private int getNumberOfCopiedRecords(Connection conn) throws IOException {
+        String cmd = "select pg_last_copy_count();";
+        Statement stmt = null;
+        ResultSet resultSet = null;
+        try {
+            stmt = conn.createStatement();
+            resultSet = stmt.executeQuery(cmd);
+            resultSet.next();
+            int numCopiedRecords = resultSet.getInt(1);
+            resultSet.close();
+            stmt.close();
+            return numCopiedRecords;
+        } catch (SQLException e) {
+            try {
+                resultSet.close();
+            } catch (Exception e1) {
+            }
+            try {
+                stmt.close();
+            } catch (Exception e1) {
+            }
+            throw new IOException(e);
+        }
+
+    }
+
+}

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/MyS3Emitter.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/MyS3Emitter.java
@@ -1,3 +1,5 @@
+// An augmentation of amazon's library here: https://github.com/awslabs/amazon-kinesis-connectors/blob/49e674efeae04734abe6f7385d7037788ea70145/src/main/java/com/amazonaws/services/kinesis/connectors/s3/S3Emitter.java#L39
+
 package com.snowplowanalytics.snowplow.kinesis;
 
 import java.io.ByteArrayInputStream;

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/MyS3Emitter.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/MyS3Emitter.java
@@ -1,0 +1,53 @@
+package com.snowplowanalytics.snowplow.kinesis;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.kinesis.connectors.KinesisConnectorConfiguration;
+import com.amazonaws.services.kinesis.connectors.UnmodifiableBuffer;
+import com.amazonaws.services.kinesis.connectors.interfaces.IEmitter;
+import com.amazonaws.services.s3.AmazonS3Client;
+
+import com.amazonaws.services.kinesis.connectors.s3.S3Emitter;
+
+public class MyS3Emitter extends S3Emitter {
+	private static final Log LOG = LogFactory.getLog(S3Emitter.class);
+
+	public MyS3Emitter(KinesisConnectorConfiguration configuration) {
+        super(configuration);
+    }
+
+	@Override
+    public List<byte[]> emit(final UnmodifiableBuffer<byte[]> buffer) throws IOException {
+        List<byte[]> records = buffer.getRecords();
+        // Write all of the records to a compressed output stream
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        for (byte[] record : records) {
+            try {
+                baos.write(record);
+            } catch (IOException e) {
+                LOG.error(e);
+                return buffer.getRecords();
+            }
+        }
+        // Get the S3 filename
+        String s3FileName = getS3FileName(buffer.getFirstSequenceNumber(), buffer.getLastSequenceNumber());
+        ByteArrayInputStream object = new ByteArrayInputStream(baos.toByteArray());
+        try {
+            s3client.putObject(s3Bucket, s3FileName, object, null);
+            LOG.info("Successfully emitted " + buffer.getRecords().size() + " records to S3 in s3://"
+                    + s3Bucket + "/" + s3FileName);
+            return Collections.emptyList();
+        } catch (AmazonServiceException e) {
+            LOG.error(e);
+            return buffer.getRecords();
+        }
+    }
+}

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/MyS3Emitter.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/MyS3Emitter.java
@@ -31,7 +31,9 @@ public class MyS3Emitter extends S3Emitter {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         for (byte[] record : records) {
             try {
-                baos.write(record);
+                String string = new String(record, "UTF-8") + "\n";
+                byte[] recordWithNewline = string.getBytes();
+                baos.write(recordWithNewline);
             } catch (IOException e) {
                 LOG.error(e);
                 return buffer.getRecords();

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/redshiftbasic/RedshiftBasicPipeline.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/redshiftbasic/RedshiftBasicPipeline.java
@@ -23,7 +23,7 @@ import com.amazonaws.services.kinesis.connectors.interfaces.IEmitter;
 import com.amazonaws.services.kinesis.connectors.interfaces.IFilter;
 import com.amazonaws.services.kinesis.connectors.interfaces.IKinesisConnectorPipeline;
 import com.amazonaws.services.kinesis.connectors.interfaces.ITransformer;
-import com.amazonaws.services.kinesis.connectors.redshift.RedshiftBasicEmitter;
+import com.snowplowanalytics.snowplow.kinesis.MyRedshiftBasicEmitter;
 
 /**
  * The Pipeline used by the Redshift basic sample. Uses:
@@ -38,7 +38,7 @@ public class RedshiftBasicPipeline implements IKinesisConnectorPipeline<String, 
 
     @Override
     public IEmitter<byte[]> getEmitter(KinesisConnectorConfiguration configuration) {
-        return new RedshiftBasicEmitter(configuration);
+        return new MyRedshiftBasicEmitter(configuration);
     }
 
     @Override


### PR DESCRIPTION
Thanks to the Snowplow team for building such a great product!

As per my comments here: https://github.com/snowplow/snowplow/pull/689

I needed to make a few changes before getting [this PR](https://github.com/snowplow/snowplow/pull/689) working locally, and successfully inserting into redshift.

Namely, this PR replaces the copy-pasted dummy schema originally from the [aws kinesis connectors library](https://github.com/awslabs/amazon-kinesis-connectors/blob/49e674efeae04734abe6f7385d7037788ea70145/src/main/samples/KinesisConnectorExecutor.java#L279) with the appropriate one resulting from the scala-kinesis-enrich app.

That schema is declared in [`scala-common-enrich`](https://github.com/snowplow/snowplow/blob/c4189163f71ec99215485eff72398ca7bfc3556d/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/outputs/EnrichedEvent.scala#L39), but from experience, not all of these events are kept.

It also inserts new lines between each event in the S3 files that will be uploaded. This is required as @pkallos mentioned in the [aforementioned PR](https://github.com/snowplow/snowplow/pull/689).

The inheritance problem, and my inexperience with java development led to a pretty wonky, but from my perspective unavoidable, solution. Let me know if there are ways around this!