### PR TITLE
Parse env vars in properties

### DIFF
--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/KinesisConnectorExecutor.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/KinesisConnectorExecutor.java
@@ -25,6 +25,7 @@ import com.snowplowanalytics.snowplow.kinesis.utils.DynamoDBUtils;
 import com.snowplowanalytics.snowplow.kinesis.utils.KinesisUtils;
 import com.snowplowanalytics.snowplow.kinesis.utils.RedshiftUtils;
 import com.snowplowanalytics.snowplow.kinesis.utils.S3Utils;
+import com.snowplowanalytics.snowplow.kinesis.utils.PropertiesUtils;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
@@ -83,8 +84,15 @@ public abstract class KinesisConnectorExecutor<T,U> extends KinesisConnectorExec
      *            The name of the configuration file to look for on the classpath
      */
     public KinesisConnectorExecutor(String configFile) {
-        InputStream configStream = Thread.currentThread().getContextClassLoader()
+        InputStream configStream;
+        InputStream rawConfigStream = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream(configFile);
+        try {
+            configStream = PropertiesUtils.parseConfigStream(rawConfigStream);
+        } catch (IOException e) {
+            String msg = "Could not parse resource " + configFile + " for environment variables";
+            throw new IllegalStateException(msg, e);
+        }
 
         if (configStream == null) {
             String msg = "Could not find resource " + configFile + " in the classpath";

--- a/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/utils/PropertiesUtils.java
+++ b/4-storage/kinesis-redshift-sink/src/main/java/com/snowplowanalytics/snowplow/kinesis/utils/PropertiesUtils.java
@@ -1,0 +1,62 @@
+package com.snowplowanalytics.snowplow.kinesis.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+/*
+ * This class helps to keep some private settings outside of *.properties files
+ * by allowing environment variables to be loaded in place of the *.properties
+ * values with similar syntax to sbt from scala: ${ENV_VAR_NAME}
+ */
+public class PropertiesUtils {
+
+	/*
+     * Returns input string with environment variable references expanded, e.g. $SOME_VAR or ${SOME_VAR}
+     * http://stackoverflow.com/a/9725352/2256243
+     */
+    public static String resolveEnvVars(String input)
+    {
+        if (null == input)
+        {
+            return null;
+        }
+        // match ${ENV_VAR_NAME} or $ENV_VAR_NAME
+        Pattern p = Pattern.compile("\\$\\{(\\w+)\\}");
+        Matcher m = p.matcher(input); // get a matcher object
+        StringBuffer sb = new StringBuffer();
+        while(m.find()){
+            String envVarName = null == m.group(1) ? m.group(2) : m.group(1);
+            String envVarValue = System.getenv(envVarName);
+            m.appendReplacement(sb, null == envVarValue ? "" : envVarValue);
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
+    // http://stackoverflow.com/a/16027293/2256243
+    public static InputStream parseConfigStream(InputStream stream) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
+        try {
+            StringBuilder sb = new StringBuilder();
+            String line = resolveEnvVars(br.readLine());
+
+            while (line != null) {
+                sb.append(line);
+                sb.append("\n");
+                line = resolveEnvVars(br.readLine());
+            }
+            String configString = sb.toString();
+            InputStream configStream = new ByteArrayInputStream(configString.getBytes(StandardCharsets.UTF_8));
+            return configStream;
+        } finally {
+            br.close();
+        }
+    }
+}


### PR DESCRIPTION
Like my [other PR](https://github.com/snowplow/snowplow/pull/996), this one is a follow up on the kinesis to redshift storage adapter.

This PR adds a little bit of logic (mostly sourced from SO) to parse ENV vars in *.properties files similarly to scala & sbt, allowing lines like:

```
redshiftEndpoint = ${REDSHIFT_ENDPOINT}
redshiftUsername = ${REDSHIFT_USERNAME}
redshiftPassword = ${REDSHIFT_PASSWORD}
redshiftURL = ${REDSHIFT_URL}
```

in say, `RedshiftBasic.properties`. That way, people can feel better about committing these files to source control (a requirement, for example, for deploying on heroku), since they won't need to expose any secrets.