### PR TITLE
Bump scala common enrich version for kinesis enrich #minor

### DIFF
--- a/3-enrich/scala-kinesis-enrich/project/Dependencies.scala
+++ b/3-enrich/scala-kinesis-enrich/project/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies {
     val config               = "1.0.2"
     val scalaUtil            = "0.1.0"
     val snowplowRawEvent     = "0.1.0"
-    val snowplowCommonEnrich = "0.2.0"
+    val snowplowCommonEnrich = "0.4.0"
     val scalazon             = "0.5"
     val scalaz7              = "7.0.0"
     val maxmindGeoip         = "0.0.5"


### PR DESCRIPTION
Noticed in production that events from some platforms were being ignored, and never making it to storage.

This PR bumps the scala common enrich version for kinesis enrich, primarily for the `mob` platform fix from https://github.com/snowplow/snowplow/pull/524
