### PR TITLE
Support environment variables in YML config files

### DIFF
--- a/3-enrich/emr-etl-runner/config/config.yml.sample
+++ b/3-enrich/emr-etl-runner/config/config.yml.sample
@@ -1,6 +1,6 @@
 :aws:
-  :access_key_id: ADD HERE
-  :secret_access_key: ADD HERE
+  :access_key_id: <%= ENV['AWS_SNOWPLOW_ACCESS_KEY'] %>
+  :secret_access_key: <%= ENV['AWS_SNOWPLOW_SECRET_KEY'] %>
 :s3:
   :region: ADD HERE
   :buckets:

--- a/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/config.rb
+++ b/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/config.rb
@@ -17,6 +17,7 @@ require 'optparse'
 require 'date'
 require 'yaml'
 require 'sluice'
+require 'erb'
 
 # Config module to hold functions related to CLI argument parsing
 # and config file reading to support the daily ETL job.
@@ -35,7 +36,10 @@ module SnowPlow
       def get_config()
 
         options = Config.parse_args()
-        config = YAML.load_file(options[:config])
+
+        # Load template and evaluate environement variables
+        config_template = ERB.new File.new(options[:config]).read
+        config = YAML.load(config_template.result(binding))
 
         # Add in the start and end dates, and our skip and debug settings
         config[:start] = options[:start]

--- a/4-storage/storage-loader/config/postgres.yml.sample
+++ b/4-storage/storage-loader/config/postgres.yml.sample
@@ -1,6 +1,6 @@
 :aws:
-  :access_key_id: ADD HERE
-  :secret_access_key: ADD HERE
+  :access_key_id: <%= ENV['AWS_SNOWPLOW_ACCESS_KEY'] %>
+  :secret_access_key: <%= ENV['AWS_SNOWPLOW_SECRET_KEY'] %>
 :s3:
   :region: ADD HERE # S3 bucket region
   :buckets:

--- a/4-storage/storage-loader/config/redshift.yml.sample
+++ b/4-storage/storage-loader/config/redshift.yml.sample
@@ -1,6 +1,6 @@
 :aws:
-  :access_key_id: ADD HERE
-  :secret_access_key: ADD HERE
+  :access_key_id: <%= ENV['AWS_SNOWPLOW_ACCESS_KEY'] %>
+  :secret_access_key: <%= ENV['AWS_SNOWPLOW_SECRET_KEY'] %>
 :s3:
   :region: ADD HERE # S3 bucket region must be the same as Redshift cluster region
   :buckets:

--- a/4-storage/storage-loader/lib/snowplow-storage-loader/config.rb
+++ b/4-storage/storage-loader/lib/snowplow-storage-loader/config.rb
@@ -17,6 +17,7 @@ require 'optparse'
 require 'date'
 require 'yaml'
 require 'sluice'
+require 'erb'
 
 # Config module to hold functions related to CLI argument parsing
 # and config file reading to support storage loading.
@@ -34,7 +35,10 @@ module SnowPlow
       def get_config()
 
         options = Config.parse_args()
-        config = YAML.load_file(options[:config])
+
+        # Load template and evaluate environement variables
+        config_template = ERB.new File.new(options[:config]).read
+        config = YAML.load(config_template.result(binding))        
 
         # Add in our skip and include settings
         config[:skip] = options[:skip]


### PR DESCRIPTION
A simple and standard support of ENV VAR in YML config files.
Mandatory to externalize AWS Keys and push config file safely into GIT.