### PR TITLE
EmrEtlRunner & StorageLoader: add support for compressing enriched events

### DIFF
--- a/3-enrich/emr-etl-runner/config/config.yml.sample
+++ b/3-enrich/emr-etl-runner/config/config.yml.sample
@@ -44,6 +44,7 @@
     :hadoop_shred: 0.2.1 # Version of the Hadoop Shredding process
   :collector_format: cloudfront # Or 'clj-tomcat' for the Clojure Collector
   :continue_on_unexpected_error: false # Set to 'true' (and set :out_errors: above) if you don't want any exceptions thrown from ETL
+  :output_compression: none # Compression only available for Redshift. Storage Loader config will have to be updated accordingly. Allowed formats: none, gzip, lzo
 :iglu:
   :schema: iglu:com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-0
   :data:

--- a/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/contracts.rb
+++ b/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/contracts.rb
@@ -118,7 +118,8 @@ module Snowplow
           :hadoop_shred => String
           }),
         :collector_format => String,
-        :continue_on_unexpected_error => Bool
+        :continue_on_unexpected_error => Bool,
+        :output_compression => String
         }),
       :iglu => IgluConfigHash
       })

--- a/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/emr_job.rb
+++ b/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/emr_job.rb
@@ -52,6 +52,7 @@ module Snowplow
         run_tstamp = Time.new
         run_id = run_tstamp.strftime("%Y-%m-%d-%H-%M-%S")
         etl_tstamp = (run_tstamp.to_f * 1000).to_i.to_s
+        output_codec = config[:etl][:output_compression]
         s3 = Sluice::Storage::S3::new_fog_s3_from(
           config[:s3][:region],
           config[:aws][:access_key_id],
@@ -199,7 +200,8 @@ module Snowplow
               "--src"        , enrich_step_output,
               "--dest"       , enrich_final_output,
               "--srcPattern" , PARTFILE_REGEXP,
-              "--s3Endpoint" , s3_endpoint
+              "--s3Endpoint" , s3_endpoint,
+              "--outputCodec", output_codec
             ]
             copy_to_s3_step.name << ": Enriched HDFS -> S3"
             @jobflow.add_step(copy_to_s3_step)
@@ -224,7 +226,8 @@ module Snowplow
               "--src"        , enrich_final_output, # Opposite way round to normal
               "--dest"       , enrich_step_output,
               "--srcPattern" , PARTFILE_REGEXP,
-              "--s3Endpoint" , s3_endpoint
+              "--s3Endpoint" , s3_endpoint,
+              "--outputCodec", output_codec
             ]
             copy_to_hdfs_step.name << ": Enriched S3 -> HDFS"
             @jobflow.add_step(copy_to_hdfs_step)
@@ -258,7 +261,8 @@ module Snowplow
               "--src"        , shred_step_output,
               "--dest"       , shred_final_output,
               "--srcPattern" , PARTFILE_REGEXP,
-              "--s3Endpoint" , s3_endpoint
+              "--s3Endpoint" , s3_endpoint,
+              "--outputCodec", output_codec
             ]
             copy_to_s3_step.name << ": Shredded HDFS -> S3"
             @jobflow.add_step(copy_to_s3_step)

--- a/4-storage/storage-loader/config/postgres.yml.sample
+++ b/4-storage/storage-loader/config/postgres.yml.sample
@@ -11,6 +11,7 @@
     :shredded:
       :good: # Not required for Postgres
       :archive: # Not required for Postgres
+  :compression: NONE  # Compression format used in EMR. Postgres only allows NONE
 :download:
   :folder: ADD HERE # Postgres-only config option. Where to store the downloaded files
 :targets:

--- a/4-storage/storage-loader/config/redshift.yml.sample
+++ b/4-storage/storage-loader/config/redshift.yml.sample
@@ -11,6 +11,7 @@
     :shredded:
       :good: ADD HERE # Must be s3:// not s3n:// for Redshift. This is the same as the :shredded:good: bucket specified for EmrEtlRunner
       :archive: ADD HERE # Where to archive shredded types to
+  :compression: NONE  # Compression format used in EMR. Allowed formats: NONE, GZIP, LZOP
 :download:
   :folder: # Not required for Redshift
 :targets:


### PR DESCRIPTION
This PR adds a configuration option in emr-etl-runner and storage-loader to compress the EMR output using gzip or lzo.