### PR TITLE
Scala Stream Collector: add healthcheck for load balancers

### DIFF
--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2013-2014 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0, and
@@ -134,6 +134,11 @@ class CollectorService(
             }
           }
         }
+      }
+    } ~
+    get {
+      path("health".r) { path =>
+        complete(responseHandler.healthy)
       }
     } ~
     get {

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/ResponseHandler.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/ResponseHandler.scala
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2013-2014 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0, and
@@ -59,7 +59,7 @@ object ResponseHandler {
 class ResponseHandler(config: CollectorConfig, sink: AbstractSink)(implicit context: ActorRefFactory) {
 
   import context.dispatcher
-  
+
   val Collector = s"${generated.Settings.shortName}-${generated.Settings.version}-" + config.sinkEnabled.toString.toLowerCase
 
   // When `/i` is requested, this is called and stores an event in the
@@ -130,7 +130,8 @@ class ResponseHandler(config: CollectorConfig, sink: AbstractSink)(implicit cont
 
     (httpResponse, sinkResponse)
   }
-
+  
+  def healthy = HttpResponse(status = 200, entity = s"OK")
   def notFound = HttpResponse(status = 404, entity = "404 Not found")
   def timeout = HttpResponse(status = 500, entity = s"Request timed out.")
 }

--- a/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
+++ b/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2013-2014 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0, and
@@ -175,6 +175,11 @@ collector {
       storedEvent.collector must beEqualTo("ssc-0.3.0-test")
       storedEvent.path must beEqualTo("/i")
       storedEvent.querystring must beEqualTo(payloadData)
+    }
+    "report itself as healthy" in {
+      CollectorGet("/health") ~> collectorService.collectorRoute ~> check {
+        response.status must beEqualTo(spray.http.StatusCodes.OK)
+      }
     }
   }
 }

--- a/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/PostSpec.scala
+++ b/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/PostSpec.scala
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2014 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0, and


### PR DESCRIPTION
We’re deploying a test instance of the scala snowplow collector behind an Amazon Elastic Load Balancer and needed a path that would return a 200 OK response. This adds a `/health` URI path that does just that with a minimum of fuss. I pulled this off the `core-2015-refresh` branch as it looked to be where the latest primary dev was happening. I’m happy to change that and pull from some other branch, if more appropriate. 

An alternate way of accomplishing the same thing would be for `/` to return a 200 OK with a `nothing to here` reply.