### PR TITLE
Scala Kinesis Enrich: unified logger configuration

### DIFF
--- a/3-enrich/scala-kinesis-enrich/project/Dependencies.scala
+++ b/3-enrich/scala-kinesis-enrich/project/Dependencies.scala
@@ -58,6 +58,7 @@ object Dependencies {
     val httpClient           = "org.apache.httpcomponents"  %  "httpclient"               % V.httpClient
     val jacksonCore          = "com.fasterxml.jackson.core" %  "jackson-core"             % V.jacksonCore
     val slf4j                = "org.slf4j"                  %  "slf4j-simple"             % V.slf4j
+    val log4jOverSlf4j       = "org.slf4j"                  %  "log4j-over-slf4j"         % V.slf4j
     val awsSdk               = "com.amazonaws"              %  "aws-java-sdk"             % V.awsSdk
     val kinesisClient        = "com.amazonaws"              %  "amazon-kinesis-client"    % V.kinesisClient
     // Scala

--- a/3-enrich/scala-kinesis-enrich/project/SnowplowKinesisEnrichBuild.scala
+++ b/3-enrich/scala-kinesis-enrich/project/SnowplowKinesisEnrichBuild.scala
@@ -44,6 +44,7 @@ object SnowplowKinesisEnrichBuild extends Build {
         Libraries.commonsLang3,
         Libraries.thrift,
         Libraries.slf4j,
+        Libraries.log4jOverSlf4j,
         Libraries.awsSdk,
         Libraries.kinesisClient,
         Libraries.igluClient


### PR DESCRIPTION
## Problem

I can't configure logging level of Scala Kinesis Enricher. I can configure the level for Snowplow part of the app but not AWS libraries.

## Solution

Including log4j-over-slf4j unifies the way of configuring logging for both Snowplow part and AWS library. For example, I can decrease the level of logging with: ```-Dorg.slf4j.simpleLogger.defaultLogLevel=warn```