### PR TITLE
Upgrading Scala Stream Collector dependencies to Scala 2.11 and more

### DIFF
--- a/2-collectors/scala-stream-collector/project/BuildSettings.scala
+++ b/2-collectors/scala-stream-collector/project/BuildSettings.scala
@@ -23,7 +23,7 @@ object BuildSettings {
     organization          :=  "com.snowplowanalytics",
     version               :=  "0.3.0",
     description           :=  "Scala Stream Collector for Snowplow raw events",
-    scalaVersion          :=  "2.10.1",
+    scalaVersion          :=  "2.11.5",
     scalacOptions         :=  Seq("-deprecation", "-encoding", "utf8",
                                   "-unchecked", "-feature", "-target:jvm-1.7"),
     scalacOptions in Test :=  Seq("-Yrangepos"),

--- a/2-collectors/scala-stream-collector/project/Dependencies.scala
+++ b/2-collectors/scala-stream-collector/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
     val logback          = "1.1.2"
     val commonsCodec     = "1.10"
     val scalazon         = "0.10"
-    val argot            = "1.0.2"
+    val argot            = "1.0.3"
 
     // Scala (test only)
     // Using the newest version of spec (2.3.6) causes
@@ -56,7 +56,7 @@ object Dependencies {
     // Scala
     val snowplowRawEvent = "com.snowplowanalytics" %  "snowplow-thrift-raw-event" % V.snowplowRawEvent
     val collectorPayload = "com.snowplowanalytics" %  "collector-payload-1"       % V.collectorPayload
-    val argot            = "org.clapper"           %  "argot_2.10"                % V.argot
+    val argot            = "org.clapper"           %%  "argot"                    % V.argot
     val sprayCan         = "io.spray"              %% "spray-can"                 % V.spray
     val sprayRouting     = "io.spray"              %% "spray-routing"             % V.spray
     val akkaActor        = "com.typesafe.akka"     %% "akka-actor"                % V.akka

--- a/2-collectors/scala-stream-collector/project/Dependencies.scala
+++ b/2-collectors/scala-stream-collector/project/Dependencies.scala
@@ -30,17 +30,17 @@ object Dependencies {
   object V {
     // Java
     val mimepull         = "1.9.4"
-    val awsSdk           = "1.6.10"
+    val awsSdk           = "1.9.17"
 
     // Scala
     val snowplowRawEvent = "0.1.0"
     val collectorPayload = "0.0.0"
-    val spray            = "1.2.0"
-    val akka             = "2.2.3"
-    val logback          = "1.0.13"
-    val commonsCodec     = "1.5"
-    val scalazon         = "0.5"
-    val argot            = "1.0.1"
+    val spray            = "1.3.2"
+    val akka             = "2.3.9"
+    val logback          = "1.1.2"
+    val commonsCodec     = "1.10"
+    val scalazon         = "0.10"
+    val argot            = "1.0.2"
 
     // Scala (test only)
     // Using the newest version of spec (2.3.6) causes
@@ -50,15 +50,15 @@ object Dependencies {
 
   object Libraries {
     // Java
-    val mimepull         = "org.jvnet.mimepull"    %  "mimepull"                  % V.mimepull
+    val mimepull         = "org.jvnet.mimepull"    % "mimepull"                   % V.mimepull
     val awsSdk           = "com.amazonaws"         % "aws-java-sdk"               % V.awsSdk
 
     // Scala
     val snowplowRawEvent = "com.snowplowanalytics" %  "snowplow-thrift-raw-event" % V.snowplowRawEvent
     val collectorPayload = "com.snowplowanalytics" %  "collector-payload-1"       % V.collectorPayload
-    val argot            = "org.clapper"           %% "argot"                     % V.argot
-    val sprayCan         = "io.spray"              %  "spray-can"                 % V.spray
-    val sprayRouting     = "io.spray"              %  "spray-routing"             % V.spray
+    val argot            = "org.clapper"           %  "argot_2.10"                % V.argot
+    val sprayCan         = "io.spray"              %% "spray-can"                 % V.spray
+    val sprayRouting     = "io.spray"              %% "spray-routing"             % V.spray
     val akkaActor        = "com.typesafe.akka"     %% "akka-actor"                % V.akka
     val akkaSlf4j        = "com.typesafe.akka"     %% "akka-slf4j"                % V.akka
     val logback          = "ch.qos.logback"        %  "logback-classic"           % V.logback
@@ -67,6 +67,6 @@ object Dependencies {
 
     // Scala (test only)
     val specs2           = "org.specs2"            %% "specs2"                    % V.specs2   % "test"
-    val sprayTestkit     = "io.spray"              %  "spray-testkit"             % V.spray    % "test"
+    val sprayTestkit     = "io.spray"              %% "spray-testkit"             % V.spray    % "test"
   }
 }

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
@@ -64,7 +64,6 @@ class CollectorService(
     responseHandler: ResponseHandler,
     context: ActorRefFactory) extends HttpService {
   def actorRefFactory = context
-
   // TODO: reduce code duplication here
   val collectorRoute = {
     post {

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/ResponseHandler.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/ResponseHandler.scala
@@ -77,7 +77,7 @@ class ResponseHandler(config: CollectorConfig, sink: AbstractSink)(implicit cont
 
     // Construct an event object from the request.
     val timestamp: Long = System.currentTimeMillis
-
+    
     val event = new CollectorPayload(
       "iglu:com.snowplowanalytics.snowplow/CollectorPayload/thrift/1-0-0",
       ip,

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/ScalaCollectorApp.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/ScalaCollectorApp.scala
@@ -15,6 +15,9 @@
 package com.snowplowanalytics.snowplow.collectors.scalastream
 
 // Akka and Spray
+
+import java.util.concurrent.TimeUnit
+
 import akka.actor.{ActorSystem, Props}
 import akka.io.IO
 import spray.can.Http
@@ -115,7 +118,7 @@ class CollectorConfig(config: Config) {
   val p3pCP = p3p.getString("CP")
 
   private val cookie = collector.getConfig("cookie")
-  val cookieExpiration = cookie.getMilliseconds("expiration")
+  val cookieExpiration = cookie.getDuration("expiration", TimeUnit.MILLISECONDS)
   var cookieDomain = cookie.getOptionalString("domain")
 
   private val sink = collector.getConfig("sink")

--- a/3-enrich/scala-kinesis-enrich/project/Dependencies.scala
+++ b/3-enrich/scala-kinesis-enrich/project/Dependencies.scala
@@ -31,15 +31,15 @@ object Dependencies {
     val httpClient           = "4.3.1"
     val jacksonCore          = "2.3.0"
     val slf4j                = "1.7.5"
-    val awsSdk               = "1.6.11"
-    val kinesisClient        = "1.0.0"
+    val awsSdk               = "1.9.7"
+    val kinesisClient        = "1.2.0"
     // Scala
     val argot                = "1.0.1"
     val config               = "1.0.2"
     val scalaUtil            = "0.1.0"
     val snowplowRawEvent     = "0.1.0"
     val snowplowCommonEnrich = "0.11.0"
-    val scalazon             = "0.5"
+    val scalazon             = "0.10"
     val scalaz7              = "7.0.0"
     val igluClient           = "0.1.1"
     // Scala (test only)


### PR DESCRIPTION
I was getting build errors under my default Java VM (version 1.8) and downgrading each shell I used to 1.7 was making me sad, so I took a stab at upgrading all the various dependencies to the latest (Scala 2.11, AWS 1.9.17, Akka 2.3.9, Spray 1.3.2, etc). 

All tests pass. I'm putting it into production now to see how it behaves on server.
