### PR TITLE
Don't die when checking the cluster and the connection times out

### DIFF
--- a/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/emr_job.rb
+++ b/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/emr_job.rb
@@ -369,6 +369,9 @@ module Snowplow
           rescue Errno::ECONNRESET => res
             logger.warn "Got connection reset #{res}, waiting 5 minutes before checking jobflow again"
             sleep(300)
+          rescue Errno::ETIMEDOUT => to
+            logger.warn "Got connection timeout #{to}, waiting 5 minutes before checking jobflow again"
+            sleep(300)
           end
         end
 


### PR DESCRIPTION
Adding a new exception to recover from in `EmrJob.wait_for()`. We've stumbled upon this one last night.