### PR TITLE
Added initial Spark data modeling framework

### DIFF
--- a/5-data-modeling/spark/.gitignore
+++ b/5-data-modeling/spark/.gitignore
@@ -1,0 +1,14 @@
+*.class
+*.log
+
+# sbt specific
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+
+# Python
+__pycache__/
+*.py[cod]

--- a/5-data-modeling/spark/LICENSE-2.0.txt
+++ b/5-data-modeling/spark/LICENSE-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/5-data-modeling/spark/README.md
+++ b/5-data-modeling/spark/README.md
@@ -1,0 +1,32 @@
+# Spark Data Modeling
+
+Docs to come.
+
+## Copyright and license
+
+Copyright 2015 Snowplow Analytics Ltd.
+
+Licensed under the [Apache License, Version 2.0] [license] (the "License");
+you may not use this software except in compliance with the License.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+[kinesis]: http://aws.amazon.com/kinesis/
+[snowplow]: http://snowplowanalytics.com
+[hadoop-lzo]: https://github.com/twitter/hadoop-lzo
+[protobufs]: https://github.com/google/protobuf/
+[elephant-bird]: https://github.com/twitter/elephant-bird/
+[s3]: http://aws.amazon.com/s3/
+[sbt]: http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.0/sbt-launch.jar
+
+[setup]: https://github.com/snowplow/snowplow/wiki/kinesis-lzo-s3-sink-setup
+[techdocs]: https://github.com/snowplow/snowplow/wiki/kinesis-lzo-s3-sink
+
+[techdocs-image]: https://d3i6fms1cm1j0i.cloudfront.net/github/images/techdocs.png
+[setup-image]: https://d3i6fms1cm1j0i.cloudfront.net/github/images/setup.png
+[roadmap-image]: https://d3i6fms1cm1j0i.cloudfront.net/github/images/roadmap.png
+[license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/5-data-modeling/spark/project/BuildSettings.scala
+++ b/5-data-modeling/spark/project/BuildSettings.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2014 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+ // SBT
+import sbt._
+import Keys._
+
+object BuildSettings {
+
+  // Basic settings for our app
+  lazy val basicSettings = Seq[Setting[_]](
+    organization          :=  "com.snowplowanalytics",
+    version               :=  "0.1.0",
+    description           :=  "Spark data modeling",
+    scalaVersion          :=  "2.10.4",
+    scalacOptions         :=  Seq("-deprecation", "-encoding", "utf8",
+                                  "-feature", "-target:jvm-1.7"),
+    scalacOptions in Test :=  Seq("-Yrangepos"),
+    resolvers             ++= Dependencies.resolutionRepos
+  )
+
+  // Makes our SBT app settings available from within the app
+  lazy val scalifySettings = Seq(sourceGenerators in Compile <+= (sourceManaged in Compile, version, name, organization) map { (d, v, n, o) =>
+    val file = d / "settings.scala"
+    IO.write(file, """package com.snowplowanalytics.snowplow.datamodeling.spark.generated
+      |object Settings {
+      |  val organization = "%s"
+      |  val version = "%s"
+      |  val name = "%s"
+      |}
+      |""".stripMargin.format(o, v, n))
+    Seq(file)
+  })
+
+  // sbt-assembly settings for building a fat jar
+  import sbtassembly.Plugin._
+  import AssemblyKeys._
+  lazy val sbtAssemblySettings = assemblySettings ++ Seq(
+
+    // Slightly cleaner jar name
+    jarName in assembly := {
+      name.value + "-" + version.value + ".jar"
+    },
+
+    // Drop these jars
+    excludedJars in assembly <<= (fullClasspath in assembly) map { cp =>
+      val excludes = Set(
+        "jsp-api-2.1-6.1.14.jar",
+        "jsp-2.1-6.1.14.jar",
+        "jasper-compiler-5.5.12.jar",
+        "commons-beanutils-core-1.8.0.jar",
+        "commons-beanutils-1.7.0.jar",
+        "servlet-api-2.5-20081211.jar",
+        "servlet-api-2.5.jar"
+      )
+      cp filter { jar => excludes(jar.data.getName) }
+    },
+
+    mergeStrategy in assembly <<= (mergeStrategy in assembly) {
+      (old) => {
+        // case "project.clj" => MergeStrategy.discard // Leiningen build files
+        case x if x.startsWith("META-INF") => MergeStrategy.discard // Bumf
+        case x if x.endsWith(".html") => MergeStrategy.discard // More bumf
+        case PathList("com", "esotericsoftware", xs @ _*) => MergeStrategy.last // For Log$Logger.class
+        case x => old(x)
+      }
+    }
+  )
+
+  lazy val buildSettings = basicSettings ++ scalifySettings ++ sbtAssemblySettings
+}

--- a/5-data-modeling/spark/project/Dependencies.scala
+++ b/5-data-modeling/spark/project/Dependencies.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2014 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+import sbt._
+
+object Dependencies {
+
+  val resolutionRepos = Seq(
+    "Snowplow Analytics Maven releases repo" at "http://maven.snplow.com/releases/",
+    "Snowplow Analytics Maven snapshot repo" at "http://maven.snplow.com/snapshots/"
+  )
+
+  object V {
+    // Scala
+    val argot                = "1.0.1"
+    val spark                = "1.3.0"
+    val json4s               = "3.2.10" // See https://github.com/json4s/json4s/issues/212
+    val scalaz7              = "7.0.0"
+    // Scala (test only)
+    val specs2               = "2.2"
+    val scalazSpecs2         = "0.1.2"
+  }
+
+  object Libraries {
+    // Scala
+    val argot                = "org.clapper"                %% "argot"                    % V.argot
+    val sparkCore            = "org.apache.spark"           %% "spark-core"               % V.spark          % "provided"
+    val sparkMllib           = "org.apache.spark"           %% "spark-mllib"              % V.spark          % "provided"
+    val sparkSql             = "org.apache.spark"           %% "spark-sql"                % V.spark          % "provided"
+    val json4sJackson        = "org.json4s"                 %% "json4s-jackson"           % V.json4s         % "provided"
+    val scalaz7              = "org.scalaz"                 %% "scalaz-core"              % V.scalaz7
+    // Scala (test only)
+    val specs2               = "org.specs2"                 %% "specs2"                   % V.specs2         % "test"
+    val scalazSpecs2         = "org.typelevel"              %% "scalaz-specs2"            % V.scalazSpecs2   % "test"
+  }
+}

--- a/5-data-modeling/spark/project/Dependencies.scala
+++ b/5-data-modeling/spark/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
   object V {
     // Scala
     val argot                = "1.0.1"
-    val spark                = "1.3.0"
+    val spark                = "1.5.0"
     val json4s               = "3.2.10" // See https://github.com/json4s/json4s/issues/212
     val scalaz7              = "7.0.0"
     // Scala (test only)

--- a/5-data-modeling/spark/project/Dependencies.scala
+++ b/5-data-modeling/spark/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
   object V {
     // Scala
     val argot                = "1.0.1"
-    val spark                = "1.5.0"
+    val spark                = "1.5.2"
     val json4s               = "3.2.10" // See https://github.com/json4s/json4s/issues/212
     val scalaz7              = "7.0.0"
     // Scala (test only)

--- a/5-data-modeling/spark/project/Dependencies.scala
+++ b/5-data-modeling/spark/project/Dependencies.scala
@@ -15,6 +15,7 @@ import sbt._
 object Dependencies {
 
   val resolutionRepos = Seq(
+    "Snowplow Analytics" at "http://maven.snplow.com/releases/",
     "Snowplow Analytics Maven releases repo" at "http://maven.snplow.com/releases/",
     "Snowplow Analytics Maven snapshot repo" at "http://maven.snplow.com/snapshots/"
   )
@@ -22,9 +23,10 @@ object Dependencies {
   object V {
     // Scala
     val argot                = "1.0.1"
-    val spark                = "1.5.2"
+    val spark                = "1.6.1"
     val json4s               = "3.2.10" // See https://github.com/json4s/json4s/issues/212
     val scalaz7              = "7.0.0"
+    val snowplow             = "0.1.0"
     // Scala (test only)
     val specs2               = "2.2"
     val scalazSpecs2         = "0.1.2"
@@ -32,13 +34,14 @@ object Dependencies {
 
   object Libraries {
     // Scala
-    val argot                = "org.clapper"                %% "argot"                    % V.argot
-    val sparkCore            = "org.apache.spark"           %% "spark-core"               % V.spark          % "provided"
-    val sparkMllib           = "org.apache.spark"           %% "spark-mllib"              % V.spark          % "provided"
-    val sparkSql             = "org.apache.spark"           %% "spark-sql"                % V.spark          % "provided"
-    val sparkHive            = "org.apache.spark"           %% "spark-hive"               % V.spark          % "provided"
-    val json4sJackson        = "org.json4s"                 %% "json4s-jackson"           % V.json4s         % "provided"
-    val scalaz7              = "org.scalaz"                 %% "scalaz-core"              % V.scalaz7
+    val argot                = "org.clapper"                %% "argot"                        % V.argot
+    val sparkCore            = "org.apache.spark"           %% "spark-core"                   % V.spark          % "provided"
+    val sparkMllib           = "org.apache.spark"           %% "spark-mllib"                  % V.spark          % "provided"
+    val sparkSql             = "org.apache.spark"           %% "spark-sql"                    % V.spark          % "provided"
+    val sparkHive            = "org.apache.spark"           %% "spark-hive"                   % V.spark          % "provided"
+    val json4sJackson        = "org.json4s"                 %% "json4s-jackson"               % V.json4s         % "provided"
+    val scalaz7              = "org.scalaz"                 %% "scalaz-core"                  % V.scalaz7
+    val analyticsSdk        = "com.snowplowanalytics"       %% "snowplow-scala-analytics-sdk" % V.snowplow
     // Scala (test only)
     val specs2               = "org.specs2"                 %% "specs2"                   % V.specs2         % "test"
     val scalazSpecs2         = "org.typelevel"              %% "scalaz-specs2"            % V.scalazSpecs2   % "test"

--- a/5-data-modeling/spark/project/Dependencies.scala
+++ b/5-data-modeling/spark/project/Dependencies.scala
@@ -36,6 +36,7 @@ object Dependencies {
     val sparkCore            = "org.apache.spark"           %% "spark-core"               % V.spark          % "provided"
     val sparkMllib           = "org.apache.spark"           %% "spark-mllib"              % V.spark          % "provided"
     val sparkSql             = "org.apache.spark"           %% "spark-sql"                % V.spark          % "provided"
+    val sparkHive            = "org.apache.spark"           %% "spark-hive"               % V.spark          % "provided"
     val json4sJackson        = "org.json4s"                 %% "json4s-jackson"           % V.json4s         % "provided"
     val scalaz7              = "org.scalaz"                 %% "scalaz-core"              % V.scalaz7
     // Scala (test only)

--- a/5-data-modeling/spark/project/SparkDataModelingBuild.scala
+++ b/5-data-modeling/spark/project/SparkDataModelingBuild.scala
@@ -1,0 +1,41 @@
+/* 
+ * Copyright (c) 2013-2014 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+import sbt._
+import Keys._
+
+object SparkDataModelingBuild extends Build {
+
+  import Dependencies._
+  import BuildSettings._
+
+  // Configure prompt to show current project
+  override lazy val settings = super.settings :+ {
+    shellPrompt := { s => Project.extract(s).currentProject.id + " > " }
+  }
+
+  // Define our project, with basic project information and library dependencies
+  lazy val project = Project("spark-data-modeling", file("."))
+    .settings(buildSettings: _*)
+    .settings(
+      libraryDependencies ++= Seq(
+        Libraries.argot,
+        Libraries.sparkCore,
+        Libraries.sparkMllib,
+        Libraries.sparkSql,
+        Libraries.scalaz7,
+        Libraries.json4sJackson,
+        Libraries.specs2,
+        Libraries.scalazSpecs2
+      )
+    )
+}

--- a/5-data-modeling/spark/project/SparkDataModelingBuild.scala
+++ b/5-data-modeling/spark/project/SparkDataModelingBuild.scala
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2013-2014 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
@@ -32,6 +32,7 @@ object SparkDataModelingBuild extends Build {
         Libraries.sparkCore,
         Libraries.sparkMllib,
         Libraries.sparkSql,
+        Libraries.sparkHive,
         Libraries.scalaz7,
         Libraries.json4sJackson,
         Libraries.specs2,

--- a/5-data-modeling/spark/project/SparkDataModelingBuild.scala
+++ b/5-data-modeling/spark/project/SparkDataModelingBuild.scala
@@ -36,7 +36,8 @@ object SparkDataModelingBuild extends Build {
         Libraries.scalaz7,
         Libraries.json4sJackson,
         Libraries.specs2,
-        Libraries.scalazSpecs2
+        Libraries.scalazSpecs2,
+        Libraries.analyticsSdk
       )
     )
 }

--- a/5-data-modeling/spark/project/build.properties
+++ b/5-data-modeling/spark/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.2

--- a/5-data-modeling/spark/project/plugins.sbt
+++ b/5-data-modeling/spark/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")

--- a/5-data-modeling/spark/src/main/scala/com.snowplowanalytics.snowplow.datamodeling/package.scala
+++ b/5-data-modeling/spark/src/main/scala/com.snowplowanalytics.snowplow.datamodeling/package.scala
@@ -1,0 +1,32 @@
+ /*
+ * Copyright (c) 2015 Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache
+ * License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.
+ *
+ * See the Apache License Version 2.0 for the specific language
+ * governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.datamodeling
+
+// Scalaz
+import scalaz._
+import Scalaz._
+
+package object spark {
+
+  /**
+   * The event as a shredded, stringified JSON on Success,
+   * or a NEL of Strings on Failure.
+   */
+  type ValidatedEvent = ValidationNel[String, String]
+}

--- a/5-data-modeling/spark/src/main/scala/com.snowplowanalytics.snowplow.datamodeling/spark/DataModeling.scala
+++ b/5-data-modeling/spark/src/main/scala/com.snowplowanalytics.snowplow.datamodeling/spark/DataModeling.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2012-2013 SnowPlow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.datamodeling.spark
+
+// Spark
+import org.apache.spark.{
+  SparkContext,
+  SparkConf
+}
+import SparkContext._
+
+// Spark SQL
+import org.apache.spark.sql.SQLContext
+
+// This project
+import events.EventTransformer
+
+object DataModeling {
+  
+  private val AppName = "DataModelingJob"
+
+  // Run the data modeling. Agnostic to Spark's current mode of operation: can be run from tests as well as from main
+  def execute(master: Option[String], args: List[String], jars: Seq[String] = Nil) {
+  
+    val sc = {
+      val conf = new SparkConf().setAppName(AppName).setJars(jars)
+      for (m <- master) {
+        conf.setMaster(m)
+      }
+      new SparkContext(conf)
+    }
+   
+    val file = sc.textFile(args(0))
+
+    // Enriched event TSV -> shredded JSON
+    val jsons = file
+      .map(line => EventTransformer.transform(line))
+      .filter(_.isSuccess)
+      .map(_.toOption.get)
+
+    // Analyze
+    val sqlContext = new SQLContext(sc)
+    val events = sqlContext.jsonRDD(jsons)
+    val cityCounts = events.groupBy("geo_city").count().rdd
+
+    // TODO: reduce number of output files
+    cityCounts.saveAsTextFile(args(1))
+  }
+}

--- a/5-data-modeling/spark/src/main/scala/com.snowplowanalytics.snowplow.datamodeling/spark/DataModeling.scala
+++ b/5-data-modeling/spark/src/main/scala/com.snowplowanalytics.snowplow.datamodeling/spark/DataModeling.scala
@@ -12,6 +12,10 @@
  */
 package com.snowplowanalytics.snowplow.datamodeling.spark
 
+// Scalaz
+import scalaz._
+import Scalaz._
+
 // Spark
 import org.apache.spark.{
   SparkContext,
@@ -45,8 +49,9 @@ object DataModeling {
     // Enriched event TSV -> shredded JSON
     val jsons = file
       .map(line => EventTransformer.transform(line))
-      .filter(_.isSuccess)
-      .map(_.toOption.get)
+      .collect { case Success(event) =>
+        event
+      }
 
     // Analyze
     val sqlContext = new SQLContext(sc)

--- a/5-data-modeling/spark/src/main/scala/com.snowplowanalytics.snowplow.datamodeling/spark/DataModeling.scala
+++ b/5-data-modeling/spark/src/main/scala/com.snowplowanalytics.snowplow.datamodeling/spark/DataModeling.scala
@@ -30,12 +30,12 @@ import org.apache.spark.sql.SQLContext
 import events.EventTransformer
 
 object DataModeling {
-  
+
   private val AppName = "DataModelingJob"
 
   // Run the data modeling. Agnostic to Spark's current mode of operation: can be run from tests as well as from main
   def execute(master: Option[String], args: List[String], jars: Seq[String] = Nil) {
-  
+
     val sc = {
       val conf = new SparkConf().setAppName(AppName).setJars(jars)
       for (m <- master) {
@@ -43,7 +43,7 @@ object DataModeling {
       }
       new SparkContext(conf)
     }
-   
+
     val file = sc.textFile(args(0))
 
     // Enriched event TSV -> shredded JSON
@@ -55,7 +55,7 @@ object DataModeling {
 
     // Analyze
     val sqlContext = new SQLContext(sc)
-    val events = sqlContext.jsonRDD(jsons)
+    val events = sqlContext.read.json(jsons) // was sqlContext.jsonRDD(jsons)
     val cityCounts = events.groupBy("geo_city").count().rdd
 
     // TODO: reduce number of output files

--- a/5-data-modeling/spark/src/main/scala/com.snowplowanalytics.snowplow.datamodeling/spark/DataModelingJob.scala
+++ b/5-data-modeling/spark/src/main/scala/com.snowplowanalytics.snowplow.datamodeling/spark/DataModelingJob.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2012-2013 SnowPlow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.datamodeling.spark
+
+// Spark
+import org.apache.spark.SparkContext
+
+object DataModelingJob {
+  
+  def main(args: Array[String]) {
+    
+    // Run the data modeling
+    DataModeling.execute(
+      master    = None,
+      args      = args.toList,
+      jars      = List(SparkContext.jarOfObject(this).get)
+    )
+
+    // Exit with success
+    System.exit(0)
+  }
+}

--- a/5-data-modeling/spark/src/main/scala/com.snowplowanalytics.snowplow.datamodeling/spark/events/EventTransformer.scala
+++ b/5-data-modeling/spark/src/main/scala/com.snowplowanalytics.snowplow.datamodeling/spark/events/EventTransformer.scala
@@ -1,0 +1,327 @@
+ /*
+ * Copyright (c) 2015 Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache
+ * License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.
+ *
+ * See the Apache License Version 2.0 for the specific language
+ * governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow
+package datamodeling.spark
+package events
+
+// Scalaz
+import scalaz._
+import Scalaz._
+
+// Scala
+import scala.util.matching.Regex
+
+// json4s
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+import org.json4s.JsonDSL._
+
+// Jackson
+import com.fasterxml.jackson.core.JsonParseException
+
+// Logging
+import org.slf4j.LoggerFactory
+
+/**
+ * Object to xxx
+ */
+object EventTransformer {
+
+  private lazy val log = LoggerFactory.getLogger(getClass())
+
+  private object GeopointIndexes {
+    val latitude = 22
+    val longitude = 23
+  }
+
+  private val fields = Array(
+    "app_id",
+    "platform",
+    "etl_tstamp",
+    "collector_tstamp",
+    "dvce_tstamp",
+    "event",
+    "event_id",
+    "txn_id",
+    "name_tracker",
+    "v_tracker",
+    "v_collector",
+    "v_etl",
+    "user_id",
+    "user_ipaddress",
+    "user_fingerprint",
+    "domain_userid",
+    "domain_sessionidx",
+    "network_userid",
+    "geo_country",
+    "geo_region",
+    "geo_city",
+    "geo_zipcode",
+    "geo_latitude",
+    "geo_longitude",
+    "geo_region_name",
+    "ip_isp",
+    "ip_organization",
+    "ip_domain",
+    "ip_netspeed",
+    "page_url",
+    "page_title",
+    "page_referrer",
+    "page_urlscheme",
+    "page_urlhost",
+    "page_urlport",
+    "page_urlpath",
+    "page_urlquery",
+    "page_urlfragment",
+    "refr_urlscheme",
+    "refr_urlhost",
+    "refr_urlport",
+    "refr_urlpath",
+    "refr_urlquery",
+    "refr_urlfragment",
+    "refr_medium",
+    "refr_source",
+    "refr_term",
+    "mkt_medium",
+    "mkt_source",
+    "mkt_term",
+    "mkt_content",
+    "mkt_campaign",
+    "contexts",
+    "se_category",
+    "se_action",
+    "se_label",
+    "se_property",
+    "se_value",
+    "unstruct_event",
+    "tr_orderid",
+    "tr_affiliation",
+    "tr_total",
+    "tr_tax",
+    "tr_shipping",
+    "tr_city",
+    "tr_state",
+    "tr_country",
+    "ti_orderid",
+    "ti_sku",
+    "ti_name",
+    "ti_category",
+    "ti_price",
+    "ti_quantity",
+    "pp_xoffset_min",
+    "pp_xoffset_max",
+    "pp_yoffset_min",
+    "pp_yoffset_max",
+    "useragent",
+    "br_name",
+    "br_family",
+    "br_version",
+    "br_type",
+    "br_renderengine",
+    "br_lang",
+    "br_features_pdf",
+    "br_features_flash",
+    "br_features_java",
+    "br_features_director",
+    "br_features_quicktime",
+    "br_features_realplayer",
+    "br_features_windowsmedia",
+    "br_features_gears",
+    "br_features_silverlight",
+    "br_cookies",
+    "br_colordepth",
+    "br_viewwidth",
+    "br_viewheight",
+    "os_name",
+    "os_family",
+    "os_manufacturer",
+    "os_timezone",
+    "dvce_type",
+    "dvce_ismobile",
+    "dvce_screenwidth",
+    "dvce_screenheight",
+    "doc_charset",
+    "doc_width",
+    "doc_height",
+    "tr_currency",
+    "tr_total_base",
+    "tr_tax_base",
+    "tr_shipping_base",
+    "ti_currency",
+    "ti_price_base",
+    "base_currency",
+    "geo_timezone",
+    "mkt_clickid",
+    "mkt_network",
+    "etl_tags",
+    "dvce_sent_tstamp",
+    "refr_domain_userid",
+    "refr_device_tstamp",
+    "derived_contexts",
+    "domain_sessionid",
+    "derived_tstamp"
+    )
+
+  private val intFields = Set(
+    "txn_id",
+    "domain_sessionidx",
+    "page_urlport",
+    "refr_urlport",
+    "ti_quantity",
+    "pp_xoffset_min",
+    "pp_xoffset_max",
+    "pp_yoffset_min",
+    "pp_yoffset_max",
+    "br_viewwidth",
+    "br_viewheight",
+    "dvce_screenwidth",
+    "dvce_screenheight",
+    "doc_width",
+    "doc_height"
+    )
+  private val doubleFields = Set(
+    "geo_latitude",
+    "geo_longitude",
+    "tr_total",
+    "tr_tax",
+    "tr_shipping",
+    "ti_price",
+    "tr_total_base",
+    "tr_tax_base",
+    "tr_shipping_base",
+    "ti_price_base"
+    )
+  private val boolFields = Set(
+    "br_features_pdf",
+    "br_features_flash",
+    "br_features_java",
+    "br_features_director",
+    "br_features_quicktime",
+    "br_features_realplayer",
+    "br_features_windowsmedia",
+    "br_features_gears",
+    "br_features_silverlight",
+    "br_cookies",
+    "dvce_ismobile"
+    )
+  private val tstampFields = Set(
+    "etl_tstamp",
+    "collector_tstamp",
+    "dvce_tstamp",
+    "dvce_sent_tstamp",
+    "refr_device_tstamp",
+    "derived_tstamp"
+    )
+
+  /**
+   * Convert the value of a field to a JValue based on the name of the field
+   *
+   * @param kvPair Tuple2 of the name and value of the field
+   * @return JObject representing a single field in the JSON
+   */
+  private def converter(kvPair: (String, String)): ValidationNel[String, JObject] = {
+    val (key, value) = kvPair
+    if (value.isEmpty) {
+      JObject(key -> JNull).successNel
+    } else {
+      try {
+        if (intFields.contains(key)) {
+          JObject(key -> JInt(value.toInt)).successNel
+        } else if (doubleFields.contains(key)) {
+          JObject(key -> JDouble(value.toDouble)).successNel
+        } else if (boolFields.contains(key)) {
+          handleBooleanField(key, value)
+        } else if (tstampFields.contains(key)) {
+          JObject(key -> JString(reformatTstamp(value))).successNel
+        } else if (key == "contexts" || key == "derived_contexts") {
+          JsonShredder.parseContexts(value)
+        } else if (key == "unstruct_event") {
+          JsonShredder.parseUnstruct(value)
+        } else {
+          JObject(key -> JString(value)).successNel
+        }
+      } catch {
+        case e @ (_ : IllegalArgumentException | _: JsonParseException) =>
+          "Value [%s] is not valid for field [%s]: %s".format(value, key, e.getMessage).failNel
+      }
+    }
+  }
+
+  /**
+   * Converts a timestamp to ISO 8601 format
+   *
+   * @param tstamp Timestamp of the form YYYY-MM-DD hh:mm:ss
+   * @return ISO 8601 timestamp
+   */
+  private def reformatTstamp(tstamp: String): String = tstamp.replaceAll(" ", "T") + "Z"
+
+  /**
+   * Converts "0" to false and "1" to true
+   *
+   * @param key The field name
+   * @param value The field value - should be "0" or "1"
+   * @return Validated JObject
+   */
+  private def handleBooleanField(key: String, value: String): ValidationNel[String, JObject] =
+    value match {
+      case "1" => JObject(key -> JBool(true)).successNel
+      case "0" => JObject(key -> JBool(false)).successNel
+      case _   => "Value [%s] is not valid for field [%s]: expected 0 or 1".format(value, key).failNel
+    }
+
+  /**
+   * Converts an aray of field values to a JSON whose keys are the field names
+   *
+   * @param event Array of values for the event
+   * @return ValidatedRecord containing JSON for the event and the event_id (if it exists)
+   */
+  private def jsonifyGoodEvent(event: Array[String]): ValidatedEvent = {
+
+    if (event.size != fields.size) {
+      log.warn(s"Expected ${fields.size} fields, received ${event.size} fields. This may be caused by using an outdated version of Snowplow Kinesis Enrich.")
+    }
+
+    val geoLocation: JObject = {
+      val latitude = event(GeopointIndexes.latitude)
+      val longitude = event(GeopointIndexes.longitude)
+      if (latitude.size > 0 && longitude.size > 0) {
+        JObject("geo_location" -> JString(s"$latitude,$longitude"))
+      } else {
+        JObject()
+      }
+    }
+    val validatedJObjects: Array[ValidationNel[String, JObject]] = fields.zip(event).map(converter)
+    val switched: ValidationNel[String, List[JObject]] = validatedJObjects.toList.sequenceU
+    switched.map( x => {
+      val j = x.fold(geoLocation)(_ ~ _)
+      compact(render(j))
+    })
+  }
+
+  /**
+   * Convert an Amazon Kinesis record to a JSON string
+   *
+   * @param record Byte array representation of an enriched event string
+   * @return ValidatedRecord for the event
+   */
+  def transform(line: String): ValidatedEvent = {
+    // The -1 is necessary to prevent trailing empty strings from being discarded
+    jsonifyGoodEvent(line.split("\t", -1))
+  }
+}

--- a/5-data-modeling/spark/src/main/scala/com.snowplowanalytics.snowplow.datamodeling/spark/events/JsonShredder.scala
+++ b/5-data-modeling/spark/src/main/scala/com.snowplowanalytics.snowplow.datamodeling/spark/events/JsonShredder.scala
@@ -1,0 +1,223 @@
+ /*
+ * Copyright (c) 2015 Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache
+ * License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.
+ *
+ * See the Apache License Version 2.0 for the specific language
+ * governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.datamodeling.spark.events
+
+// Scalaz
+import scalaz._
+import Scalaz._
+
+// json4s
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+import org.json4s.JsonDSL._
+
+// Scala
+import scala.util.matching.Regex
+import scala.annotation.tailrec
+
+/**
+ * Converts unstructured events and custom contexts to a format which the Elasticsearch
+ * mapper can understand
+ */
+object JsonShredder {
+
+  private val schemaPattern = """.+:([a-zA-Z0-9_\.]+)/([a-zA-Z0-9_]+)/[^/]+/(.*)""".r
+
+  /**
+   * Create an Elasticsearch field name from a schema
+   *
+   * "iglu:com.acme/PascalCase/jsonschema/13-0-0" -> "context_com_acme_pascal_case_13"
+   *
+   * @param prefix "context" or "unstruct_event"
+   * @param schema Schema field from an incoming JSON
+   * @return Elasticsearch field name
+   */
+   // TODO: move this to shared storage/shredding utils
+   // See https://github.com/snowplow/snowplow/issues/1189
+  def fixSchema(prefix: String, schema: String): ValidationNel[String, String] = {
+    schema match {
+      case schemaPattern(organization, name, schemaVer) => {
+
+        // Split the vendor's reversed domain name using underscores rather than dots
+        val snakeCaseOrganization = organization.replaceAll("""\.""", "_").toLowerCase
+
+        // Change the name from PascalCase to snake_case if necessary
+        val snakeCaseName = name.replaceAll("([^A-Z_])([A-Z])", "$1_$2").toLowerCase
+
+        // Extract the schemaver version's model
+        val model = schemaVer.split("-")(0)
+
+        s"${prefix}_${snakeCaseOrganization}_${snakeCaseName}_${model}".successNel
+      }
+      case _ => "Schema %s does not conform to regular expression %s".format(schema, schemaPattern.toString).failNel
+    }
+  }
+
+  /**
+   * Convert a contexts JSON to an Elasticsearch-compatible JObject
+   * For example, the JSON
+   *
+   *  {
+   *    "schema": "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0",
+   *    "data": [
+   *      {
+   *        "schema": "iglu:com.acme/unduplicated/jsonschema/1-0-0",
+   *        "data": {
+   *          "unique": true
+   *        }
+   *      },
+   *      {
+   *        "schema": "iglu:com.acme/duplicated/jsonschema/1-0-0",
+   *        "data": {
+   *          "value": 1
+   *        }
+   *      },
+   *      {
+   *        "schema": "iglu:com.acme/duplicated/jsonschema/1-0-0",
+   *        "data": {
+   *          "value": 2
+   *        }
+   *      }
+   *    ]
+   *  }
+   *
+   * would become
+   *
+   *  {
+   *    "context_com_acme_duplicated_1": [{"value": 1}, {"value": 2}],
+   *    "context_com_acme_unduplicated_1": [{"unique": true}]
+   *  }
+   *
+   * @param contexts Contexts JSON
+   * @return Contexts JSON in an Elasticsearch-compatible format
+   */
+  def parseContexts(contexts: String): ValidationNel[String, JObject] = {
+
+    /**
+     * Validates and pairs up the schema and data fields without grouping the same schemas together
+     *
+     * For example, the JSON
+     *
+     *  {
+     *    "schema": "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0",
+     *    "data": [
+     *      {
+     *        "schema": "iglu:com.acme/duplicated/jsonschema/1-0-0",
+     *        "data": {
+     *          "value": 1
+     *        }
+     *      },
+     *      {
+     *        "schema": "iglu:com.acme/duplicated/jsonschema/1-0-0",
+     *        "data": {
+     *          "value": 2
+     *        }
+     *      }
+     *    ]
+     *  }
+     *
+     * would become
+     *
+     * [
+     *   {"context_com_acme_duplicated_1": {"value": 1}},
+     *   {"context_com_acme_duplicated_1": {"value": 2}}
+     * ]
+     *
+     * @param contextJsons List of inner custom context JSONs
+     * @param accumulator Custom contexts which have already been parsed
+     * @return List of validated tuples containing a fixed schema string and the original data JObject
+     */
+    @tailrec def innerParseContexts(contextJsons: List[JValue], accumulator: List[ValidationNel[String, (String, JValue)]]):
+      List[ValidationNel[String, (String, JValue)]] = {
+
+      contextJsons match {
+        case Nil => accumulator
+        case head :: tail => {
+          val context = head
+          val innerData = context \ "data" match {
+            case JNothing => "Could not extract inner data field from custom context".failNel // TODO: decide whether to enforce object type of data
+            case d => d.successNel
+          }
+          val fixedSchema: ValidationNel[String, String] = context \ "schema" match {
+            case JString(schema) => fixSchema("contexts", schema)
+            case _ => "Context JSON did not contain a stringly typed schema field".failNel
+          }
+
+          val schemaDataPair = (fixedSchema |@| innerData) {_ -> _}
+
+          innerParseContexts(tail, schemaDataPair :: accumulator)
+        }
+      }
+    }
+
+    val json = parse(contexts)
+    val data = json \ "data"
+
+    data match {
+      case JArray(Nil) => "Custom contexts data array is empty".failNel
+      case JArray(ls) => {
+        val innerContexts: ValidationNel[String, List[(String, JValue)]] = innerParseContexts(ls, Nil).sequenceU
+
+        // Group contexts with the same schema together
+        innerContexts.map(_.groupBy(_._1).map(pair => (pair._1, pair._2.map(_._2))))
+      }
+      case _ => "Could not extract contexts data field as an array".failNel
+    }
+
+  }
+
+  /**
+   * Convert an unstructured event JSON to an Elasticsearch-compatible JObject
+   * For example, the JSON
+   *
+   *  {
+   *    "schema": "iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0",
+   *    "data": {
+   *      "schema": "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1",
+   *      "data": {
+   *        "key": "value"
+   *      }
+   *    }
+   *  }
+   *
+   * would become
+   *
+   *  {
+   *    "unstruct_com_snowplowanalytics_snowplow_link_click_1": {"key": "value"}
+   *  }
+   *
+   * @param unstruct Unstructured event JSON
+   * @return Unstructured event JSON in an Elasticsearch-compatible format
+   */
+  def parseUnstruct(unstruct: String): ValidationNel[String, JObject] = {
+    val json = parse(unstruct)
+    val data = json \ "data"
+    val schema = data \ "schema"
+    val innerData = data \ "data" match {
+      case JNothing => "Could not extract inner data field from unstructured event".failNel // TODO: decide whether to enforce object type of data
+      case d => d.successNel
+    }
+    val fixedSchema = schema match {
+      case JString(s) => fixSchema("unstruct_event", s)
+      case _ => "Unstructured event JSON did not contain a stringly typed schema field".failNel
+    }
+
+    (fixedSchema |@| innerData) {_ -> _}
+  }
+}

--- a/5-data-modeling/spark/tasks.py
+++ b/5-data-modeling/spark/tasks.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+#
+# This program is licensed to you under the Apache License Version 2.0,
+# and you may not use this file except in compliance with the Apache License Version 2.0.
+# You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the Apache License Version 2.0 is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+from invoke import run, task
+
+import boto.s3
+from boto.s3.connection import Location
+from boto.s3.key import Key
+
+import boto.emr
+from boto.emr.step import InstallHiveStep, ScriptRunnerStep
+from boto.emr.bootstrap_action import BootstrapAction
+
+JAR_FILE  = "spark-data-modeling-0.1.0.jar"
+
+S3_REGIONS = { 'us-east-1': Location.DEFAULT,
+                 'us-west-1': Location.USWest,
+                 'us-west-2': Location.USWest2,
+                 'eu-west-1': Location.EU,
+                 'ap-southeast-1': Location.APSoutheast,
+                 'ap-southeast-2': Location.APSoutheast2,
+                 'ap-northeast-1': Location.APNortheast,
+                 'sa-east-1': Location.SAEast }
+
+S3_LOCATIONS = {v: k for k, v in S3_REGIONS.items()}
+
+# Taken from https://github.com/bencpeters/save-tweets/blob/ac276fac41e676ee12a426df56cbc60138a12e62/save-tweets.py
+def get_valid_location(region):
+    if region not in [i for i in dir(boto.s3.connection.Location) \
+                               if i[0].isupper()]:
+        try:
+            return S3_REGIONS[region]
+        except KeyError:
+            raise ValueError("%s is not a known AWS location. Valid choices " \
+                 "are:\n%s" % (region,  "\n".join( \
+                 ["  *%s" % i for i in S3_REGIONS.keys()])))
+    else:
+        return getattr(Location, region)
+
+def get_valid_region(location):
+    return S3_LOCATIONS[location]
+
+@task
+def test():
+    run("sbt test", pty=True)
+
+@task
+def assembly():
+   run("sbt assembly", pty=True)
+
+#@task
+#def create_ec2_key(profile, ...)
+
+#@task
+#def create_public_subnet(profile, ...)
+
+#@task
+#def create_bucket(profile, bucket, region):
+#    c = boto.connect_s3(profile_name=profile)
+#    c.create_bucket(bucket, location=get_valid_location(region))
+
+@task
+def upload(profile, bucket):
+    c = boto.connect_s3(profile_name=profile)    
+    b = c.get_bucket(bucket)
+    
+    k2 = Key(b)
+    k2.key = "jar/" + JAR_FILE
+    k2.set_contents_from_filename("./target/scala-2.10/" + JAR_FILE)
+
+@task
+def run_emr(profile, bucket, ec2_keyname, vpc_subnet_id):
+    c = boto.connect_s3(profile_name=profile)    
+    b = c.get_bucket(bucket)    
+    r = get_valid_region(b.get_location())
+
+    bootstrap_actions = [
+        BootstrapAction("Install Spark", "s3://support.elasticmapreduce/spark/install-spark", ["-x"])
+    ]
+
+    args = [
+        "/home/hadoop/spark/bin/spark-submit",
+        "--deploy-mode",
+        "cluster",
+        "--master",
+        "yarn-cluster",
+        "--class",
+        "com.snowplowanalytics.snowplow.datamodeling.spark.DataModelingJob",
+        "s3://" + bucket + "/jar/" + JAR_FILE,
+        "s3n://" + bucket + "/in",
+        "s3n://" + bucket + "/out"
+    ]
+    steps = [
+        InstallHiveStep(),
+        ScriptRunnerStep("Run Data Modeling", step_args=args)
+    ]
+
+    conn = boto.emr.connect_to_region(r, profile_name=profile)
+    job_id = conn.run_jobflow(
+        name="Spark Data Modeling",
+        log_uri="s3://" + bucket + "/logs",
+        ec2_keyname=ec2_keyname,
+        master_instance_type="m3.xlarge",
+        slave_instance_type="m3.xlarge",
+        num_instances=3,
+        enable_debugging=True,
+        ami_version="3.6",
+        steps=steps,
+        bootstrap_actions=bootstrap_actions,
+        job_flow_role="EMR_EC2_DefaultRole",
+        service_role="EMR_DefaultRole"
+    )
+    print "Started jobflow " + job_id


### PR DESCRIPTION
@yalisassoon, @bogaert - this is a PR for an initial (functional) data modeling framework using Spark.

It is designed to work with the most recent version of the Snowplow enriched event format. As a placeholder for some serious data modeling, the initial version simply counts the number of events by geo_city.

Snowplow enriched events are converted into the exact same JSON format as that used to load into Elasticsearch, prior to analysis.

You can run the fat jar on Elastic MapReduce using the `inv run_emr` function. Check `tasks.py` for other helper functions.

For more background, see this weekend's release of the new spark-example-project: https://github.com/snowplow/spark-example-project
