### PR TITLE
Update default EMR instance type to m1.medium

### DIFF
--- a/3-enrich/emr-etl-runner/config/config.yml.sample
+++ b/3-enrich/emr-etl-runner/config/config.yml.sample
@@ -34,11 +34,11 @@
     :lingual:              # To launch on cluster, provide version, "1.1", keep quotes
   # Adjust your Hadoop cluster below
   :jobflow:
-    :master_instance_type: m1.small
+    :master_instance_type: m1.medium
     :core_instance_count: 2
-    :core_instance_type: m1.small
+    :core_instance_type: m1.medium
     :task_instance_count: 0 # Increase to use spot instances
-    :task_instance_type: m1.small
+    :task_instance_type: m1.medium
     :task_instance_bid: 0.015 # In USD. Adjust bid, or leave blank for non-spot-priced (i.e. on-demand) task instances
 :etl:
   :job_name: Snowplow ETL # Give your job a name


### PR DESCRIPTION
Now that Snowplow EMR is using Hadoop 2 / AMI 3.6.0, the `m1.small` instance type is not supported; the sample config should list the `m1.medium` type.  See [AWS EMR Documentation](http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-plan-instances.html): "In Amazon EMR, m1.small and m1.medium instances are recommended only for testing purposes and m1.small is not supported on Hadoop 2 clusters."