### PR TITLE
Upgrade default instance types in emr-etl-runner sample config

### DIFF
--- a/3-enrich/emr-etl-runner/config/config.yml.sample
+++ b/3-enrich/emr-etl-runner/config/config.yml.sample
@@ -35,11 +35,11 @@
     :lingual:              # To launch on cluster, provide version, "1.1", keep quotes
   # Adjust your Hadoop cluster below
   :jobflow:
-    :master_instance_type: m1.small
-    :core_instance_count: 2
-    :core_instance_type: m1.small
+    :master_instance_type: m1.medium
+    :core_instance_count: 1
+    :core_instance_type: m1.medium
     :task_instance_count: 0 # Increase to use spot instances
-    :task_instance_type: m1.small
+    :task_instance_type: m1.medium
     :task_instance_bid: 0.015 # In USD. Adjust bid, or leave blank for non-spot-priced (i.e. on-demand) task instances
 :etl:
   :job_name: Snowplow ETL # Give your job a name


### PR DESCRIPTION
Instance type m1.small was only available to Hadoop 1, so with the 3.6.0
AMIs the instance type needs to be updated.

See: http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-plan-ec2-instances.html