### PR TITLE
Snowplow CLI: expose the sslmode connection option for loading Postgres and Redshift

### DIFF
--- a/3-enrich/emr-etl-runner/config/config.yml.sample
+++ b/3-enrich/emr-etl-runner/config/config.yml.sample
@@ -63,6 +63,7 @@ storage:
       host: ADD HERE # The endpoint as shown in the Redshift console
       database: ADD HERE # Name of database
       port: 5439 # Default Redshift port
+      sslmode: disable # One of disable (default), require, verify-ca or verify-full
       table: atomic.events
       username: ADD HERE
       password: ADD HERE
@@ -73,6 +74,7 @@ storage:
       host: ADD HERE # Hostname of database server
       database: ADD HERE # Name of database
       port: 5432 # Default Postgres port
+      sslmode: disable # One of disable (default), require, verify-ca or verify-full
       table: atomic.events
       username: ADD HERE
       password: ADD HERE

--- a/4-storage/storage-loader/lib/snowplow-storage-loader/postgres_loader.rb
+++ b/4-storage/storage-loader/lib/snowplow-storage-loader/postgres_loader.rb
@@ -177,6 +177,7 @@ module Snowplow
         props = java.util.Properties.new
         props.set_property :user, target[:username]
         props.set_property :password, target[:password]
+        props.set_property :sslmode, target.fetch(:sslmode, "disable")
 
         # Used instead of Java::JavaSql::DriverManager.getConnection to prevent "no suitable driver found" error
         org.postgresql.Driver.new.connect(connection_url, props)


### PR DESCRIPTION
Modification required to enable the SQL runner to connect to AWS Redshift databases where the database's associated parameter group (http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-parameter-groups.html) only permits SSL connections (require_ssl: true).

Note: I'd prefer to specify the default as 'allow' (I don't care about security, but I will pay the overhead of encryption if the server insists on it) but the underlying implementation (https://github.com/pgjdbc/pgjdbc/blob/master/org/postgresql/core/v3/ConnectionFactoryImpl.java) doesn't support the 'allow' or 'prefer' sslmode options.