### PR TITLE
env-encrich-conf: use envs  for emr config

### DIFF
--- a/3-enrich/emr-etl-runner/config/config.yml.sample
+++ b/3-enrich/emr-etl-runner/config/config.yml.sample
@@ -3,102 +3,102 @@ aws:
   access_key_id: <%= ENV['AWS_SNOWPLOW_ACCESS_KEY'] %>
   secret_access_key: <%= ENV['AWS_SNOWPLOW_SECRET_KEY'] %>
   s3:
-    region: ADD HERE
+    region: <% ENV.fetch('S3_REGION','') %>
     buckets:
-      assets: s3://snowplow-hosted-assets # DO NOT CHANGE unless you are hosting the jarfiles etc yourself in your own bucket
-      jsonpath_assets: # If you have defined your own JSON Schemas, add the s3:// path to your own JSON Path files in your own bucket here
-      log: ADD HERE
+      assets: <% ENV.fetch('S3_ASSETS',"s3://snowplow-hosted-assets") %>                # DO NOT CHANGE unless you are hosting the jarfiles etc yourself in your own bucket
+      jsonpath_assets: <% ENV.fetch('S3_JSONPATH_ASSETS','') %>                         # If you have defined your own JSON Schemas, add the s3:// path to your own JSON Path files in your own bucket here
+      log: <% ENV.fetch('LOG','') %>
       raw:
-        in:                  # Multiple in buckets are permitted
-          - ADD HERE          # e.g. s3://my-in-bucket
-          - ADD HERE
-        processing: ADD HERE
-        archive: ADD HERE    # e.g. s3://my-archive-bucket/raw
+        in:                                                                             # Multiple in buckets are permitted
+          - <% ENV.fetch('S3_RAW_IN_0','')                                              # e.g. s3://my-archive-bucket/raw
+          - <% ENV.fetch('S3_RAW_IN_1','')                                              # e.g. s3://my-archive-bucket/raw
+        processing: <% ENV.fetch('S3_RAW_PROCESSING','') %>
+        archive: <% ENV.fetch('S3_RAW_ARCHIVE','') %>                                   # e.g. s3://my-archive-bucket/raw
       enriched:
-        good: ADD HERE       # e.g. s3://my-out-bucket/enriched/good
-        bad: ADD HERE        # e.g. s3://my-out-bucket/enriched/bad
-        errors: ADD HERE     # Leave blank unless :continue_on_unexpected_error: set to true below
-        archive: ADD HERE    # Where to archive enriched events to, e.g. s3://my-archive-bucket/enriched
+        good: <% ENV.fetch('ENRICHED_GOOD','') %>                                       # e.g. s3://my-out-bucket/enriched/good
+        bad: <% ENV.fetch('ENRICHED_BAD','') %>                                         # e.g. s3://my-out-bucket/enriched/bad
+        errors: <% ENV['ENRICHED_ERRORS'] %>                                            # Leave blank unless :continue_on_unexpected_error: set to true below
+        archive: <% ENV.fetch('ENRICHDED_ARCHIVE','') %>                                # Where to archive enriched events to, e.g. s3://my-out-bucket/enriched/archive
       shredded:
-        good: ADD HERE       # e.g. s3://my-out-bucket/shredded/good
-        bad: ADD HERE        # e.g. s3://my-out-bucket/shredded/bad
-        errors: ADD HERE     # Leave blank unless :continue_on_unexpected_error: set to true below
-        archive: ADD HERE    # Where to archive shredded events to, e.g. s3://my-archive-bucket/shredded
+        good: <% ENV.fetch('SHREDDED_GOOD','') %>                                       # e.g. s3://my-out-bucket/shredded/good
+        bad: <% ENV.fetch('SHREDDED_BAD','') %>                                         # e.g. s3://my-out-bucket/shredded/bad
+        errors: <% ENV['SHREDDED_ERRORS'] %>                                            # Leave blank unless :continue_on_unexpected_error: set to true below
+        archive: <% ENV.fetch('SHREDDED_ARCHIVE','') %>                                 # Not required for Postgres currently
   emr:
-    ami_version: 3.7.0      # Don't change this
-    region: ADD HERE        # Always set this
-    jobflow_role: EMR_EC2_DefaultRole # Created using $ aws emr create-default-roles
-    service_role: EMR_DefaultRole     # Created using $ aws emr create-default-roles
-    placement: ADD HERE     # Set this if not running in VPC. Leave blank otherwise
-    ec2_subnet_id: ADD HERE # Set this if running in VPC. Leave blank otherwise
-    ec2_key_name: ADD HERE
-    bootstrap: []           # Set this to specify custom boostrap actions. Leave empty otherwise
+    ami_version: 3.7.0                                                                  # Don't change this
+    region: <% ENV.fetch('EMR_REGION','') %>                                            # Always set this
+    jobflow_role: EMR_EC2_DefaultRole                                                   # Created using $ aws emr create-default-roles
+    service_role: EMR_DefaultRole                                                       # Created using $ aws emr create-default-roles
+    placement: <% ENV['EMR_PLACEMENT'] %>                                               # Set this if not running in VPC. Leave blank otherwise
+    ec2_subnet_id: <% ENV['EMR_EC2_SUBNET_ID'] %>                                       # Set this if running in VPC. Leave blank otherwise
+    ec2_key_name: <% ENV.fetch('EMR_EC2_KEY_NAME','') %>
+    bootstrap: []                                                                       # Set this to specify custom boostrap actions. Leave empty otherwise
     software:
-      hbase:                # To launch on cluster, provide version, "0.92.0", keep quotes
-      lingual:              # To launch on cluster, provide version, "1.1", keep quotes
+      hbase: <% ENV['SOFTWARE_HBASE'] %>                                                # To launch on cluster, provide version, "0.92.0", keep quotes
+      lingual: <% ENV['SOFTWARE_LINGUAL'] %>                                            # To launch on cluster, provide version, "1.1", keep quotes
     # Adjust your Hadoop cluster below
     jobflow:
       master_instance_type: m1.medium
       core_instance_count: 2
       core_instance_type: m1.medium
-      task_instance_count: 0 # Increase to use spot instances
+      task_instance_count: <% ENV.fetch('JOBFLOW_TASK_INSTANCE_COUNT', 0) %>            # Increase to use spot instances
       task_instance_type: m1.medium
-      task_instance_bid: 0.015 # In USD. Adjust bid, or leave blank for non-spot-priced (i.e. on-demand) task instances
-    bootstrap_failure_tries: 3 # Number of times to attempt the job in the event of bootstrap failures
+      task_instance_bid: <% ENV['JOBFLOW_TASK_INSTANCE_BID'] %>                         # In USD. Adjust bid, or leave blank for non-spot-priced (i.e. on-demand) task instances
+    bootstrap_failure_tries: <% ENV.fetch('BOOTSTRAP_FAILURE_TRIES', 3) %>              # Number of times to attempt the job in the event of bootstrap failures
 collectors:
-  format: cloudfront # For example: 'clj-tomcat' for the Clojure Collector, 'thrift' for Thrift records, 'tsv/com.amazon.aws.cloudfront/wd_access_log' for Cloudfront access logs or 'ndjson/urbanairship.connect/v1' for UrbanAirship Connect events
+  format: cloudfront                                                                    # For example: 'clj-tomcat' for the Clojure Collector, 'thrift' for Thrift records, 'tsv/com.amazon.aws.cloudfront/wd_access_log' for Cloudfront access logs or 'ndjson/urbanairship.connect/v1' for UrbanAirship Connect events
 enrich:
-  job_name: Snowplow ETL # Give your job a name
+  job_name: <% ENV.fetch('ENRICH_JOB_NAME','Snowplow ETL') %>                           # Give your job a name
   versions:
-    hadoop_enrich: 1.5.1 # Version of the Hadoop Enrichment process
-    hadoop_shred: 0.7.0 # Version of the Hadoop Shredding process
-    hadoop_elasticsearch: 0.1.0 # Version of the Hadoop to Elasticsearch copying process
-  continue_on_unexpected_error: false # Set to 'true' (and set :out_errors: above) if you don't want any exceptions thrown from ETL
-  output_compression: NONE # Compression only supported with Redshift, set to NONE if you have Postgres targets. Allowed formats: NONE, GZIP
+    hadoop_enrich: 1.5.1                                                                # Version of the Hadoop Enrichment process
+    hadoop_shred: 0.7.0                                                                 # Version of the Hadoop Shredding process
+    hadoop_elasticsearch: 0.1.0                                                         # Version of the Hadoop to Elasticsearch copying process
+  continue_on_unexpected_error: <% ENV.fetch('CONTINUE_ON_UNEXPECTED_ERROR', false) %>  # Set to 'true' (and set :out_errors: above) if you don't want any exceptions thrown from ETL
+  output_compression: <% ENV.fetch('OUTPUT_COMPRESSION', NONE) %>                       # Compression only supported with Redshift, set to NONE if you have Postgres targets. Allowed formats: NONE, GZIP
 storage:
   download:
-    folder: # Postgres-only config option. Where to store the downloaded files. Leave blank for Redshift
+    folder: <% ENV['STORAGE_DOWNLOAD_FOLDER'] %>                                        # Postgres-only config option. Where to store the downloaded files. Leave blank for Redshift
   targets:
-    - name: "My Redshift database"
+    - name: <% ENV.fetch('REDSHIFT_NAME_0','My Redshift database') %>
       type: redshift
-      host: ADD HERE # The endpoint as shown in the Redshift console
-      database: ADD HERE # Name of database
-      port: 5439 # Default Redshift port
-      ssl_mode: disable # One of disable (default), require, verify-ca or verify-full
-      table: atomic.events
-      username: ADD HERE
-      password: ADD HERE
-      maxerror: 1 # Stop loading on first error, or increase to permit more load errors
-      comprows: 200000 # Default for a 1 XL node cluster. Not used unless --include compupdate specified
-    - name: "My PostgreSQL database"
+      host: <% ENV.fetch('REDSHIFT_HOST_0','') %>                                       # The endpoint as shown in the Redshift console
+      database: <% ENV.fetch('REDSHIFT_DATABASE_0','') %>                               # Name of database
+      port: <% ENV.fetch('REDSHIFT_PORT_0', 5439) %>                                    # Default Redshift port
+      ssl_mode: <% ENV.fetch('REDSHIFT_SSL_MODE_0','disable ') %>                       # One of disable (default), require, verify-ca or verify-full
+      table: <% ENV.fetch('REDSHIFT_TABLE_0','atomic.events') %>
+      username: <% ENV.fetch('REDSHIFT_USERNAME_0','') %>
+      password: <% ENV.fetch('REDSHIFT_PASSWORD_0','') %>
+      maxerror: <% ENV.fetch('REDSHIFT_MAXERROR_0', 1) %>                               # Stop loading on first error, or increase to permit more load errors
+      comprows: <% ENV.fetch('REDSHIFT_COMPROWS_0', 200000) %>                          # Default for a 1 XL node cluster. Not used unless --include compupdate specified
+    - name: <% ENV.fetch('POSTGRES_NAME_0','My PostgreSQL database') %>
       type: postgres
-      host: ADD HERE # Hostname of database server
-      database: ADD HERE # Name of database
-      port: 5432 # Default Postgres port
-      ssl_mode: disable # One of disable (default), require, verify-ca or verify-full
-      table: atomic.events
-      username: ADD HERE
-      password: ADD HERE
-      maxerror: # Not required for Postgres
-      comprows: # Not required for Postgres
-    - name: "My Elasticsearch database"
+      host: <% ENV.fetch('POSTGRES_HOST_0','') %>                                       # Hostname of database server
+      database: <% ENV.fetch('POSTGRES_DATABASE_0','') %>                               # Name of database
+      port: <% ENV.fetch('POSTGRES_PORT_0', 5432) %>                                    # Default postgres port
+      ssl_mode: <% ENV.fetch('POSTGRES_SSL_MODE_0','disable ') %>                       # One of disable (default), require, verify-ca or verify-full
+      table: <% ENV.fetch('POSTGRES_TABLE_0','atomic.events') %>
+      username: <% ENV.fetch('POSTGRES_USERNAME_0','') %>
+      password: <% ENV.fetch('POSTGRES_PASSWORD_0','') %>
+      #maxerror: # Not required for postgres
+      #comprows: # Not required for postgres
+    - name: <% ENV.fetch('ELASTIC_SEARCH_NAME_0','My Elasticsearch database') %>
       type: elasticsearch
-      host: ADD HERE # The Elasticsearch endpoint
-      database: ADD HERE # Name of index
-      port: 9200 # Default Elasticsearch port - change to 80 if using Amazon Elasticsearch Service
-      sources: # Leave blank to write the bad rows created in this run to Elasticsearch, or explicitly provide an array of bad row buckets like ["s3://my-enriched-bucket/bad/run=2015-10-06-15-25-53"]
-      ssl_mode: # Not required for Elasticsearch
-      table: ADD HERE # Name of type
-      username: # Not required for Elasticsearch
-      password: # Not required for Elasticsearch
-      es_nodes_wan_only: false # Set to true if using Amazon Elasticsearch Service
-      maxerror: # Not required for Elasticsearch
-      comprows: # Not required for Elasticsearch
+      host: <% ENV.fetch('ELASTIC_SEARCH_HOST_0','') %>                                 # The Elasticsearch endpoint
+      database: <% ENV.fetch('ELASTIC_SEARCH_DATABASE_0','') %>                         # Name of index
+      port: <% ENV.fetch('ELASTIC_SEARCH_PORT_0', 9200) %>                              # Default Elasticsearch port - change to 80 if using Amazon Elasticsearch Service
+      sources:                                                                          # Leave blank to write the bad rows created in this run to Elasticsearch, or explicitly provide an array of bad
+      table: <% ENV.fetch('ELASTIC_SEARCH_TABLE_0','') %>                               # Name of type
+      es_nodes_wan_only: <% ENV.fetch('ELASTIC_SEARCH_NODES_WAN_ONLY_0','false') %>     # Set to true if using Amazon Elasticsearch Service
+      # ssl_mode: # Not required for Elasticsearch
+      # username: # Not required for Elasticsearch
+      # password: # Not required for Elasticsearch
+      # maxerror: # Not required for Elasticsearch
+      # comprows: # Not required for Elasticsearch
 monitoring:
   tags: {} # Name-value pairs describing this job
   logging:
-    level: DEBUG # You can optionally switch to INFO for production
+  level: <% ENV.fetch('LOGGING_LEVEL','DEBUG') %>                                       # You can optionally switch to INFO for production
   snowplow:
     method: get
-    app_id: ADD HERE # e.g. snowplow
-    collector: ADD HERE # e.g. d3rkrsqld9gmqf.cloudfront.net
+    app_id: <% ENV.fetch('MONITORING_SNOWPLOW_APP_ID','') %>                            # e.g. snowplow
+    collector: <% ENV.fetch('MONITORING_SNOWPLOW_COLLECTOR','') %>                      # e.g. d3rkrsqld9gmqf.cloudfront.net


### PR DESCRIPTION
This PR uses ENV values for the config of the emr-etl-runner.
Previous defaults are used where appropriate (leaving blank/nil where they should be). 
It makes it much each to configure when using docker containers.
