### PR TITLE
Added support for disabling column truncation under Redshift COPY

### DIFF
--- a/3-enrich/emr-etl-runner/config/config.yml.sample
+++ b/3-enrich/emr-etl-runner/config/config.yml.sample
@@ -68,6 +68,7 @@ storage:
       username: ADD HERE
       password: ADD HERE
       maxerror: 1 # Stop loading on first error, or increase to permit more load errors
+      truncate_columns: true # Truncates data in columns to the appropriate number of characters so that it fits the column specification
       comprows: 200000 # Default for a 1 XL node cluster. Not used unless --include compupdate specified
     - name: "My PostgreSQL database"
       type: postgres
@@ -79,6 +80,7 @@ storage:
       username: ADD HERE
       password: ADD HERE
       maxerror: # Not required for Postgres
+      truncate_columns: true # Not required for Postgres
       comprows: # Not required for Postgres
 monitoring:
   tags: {} # Name-value pairs describing this job

--- a/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/contracts.rb
+++ b/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/contracts.rb
@@ -80,6 +80,7 @@ module Snowplow
       :username => String,
       :password => String,
       :maxerror => Maybe[Num],
+      :truncate_columns => MayBe[Bool],
       :comprows => Maybe[Num]
       })
 

--- a/4-storage/storage-loader/lib/snowplow-storage-loader/redshift_loader.rb
+++ b/4-storage/storage-loader/lib/snowplow-storage-loader/redshift_loader.rb
@@ -167,8 +167,14 @@ module Snowplow
           else
             ""
           end
+        truncate_columns =
+          if config.fetch(:truncate_columns, true)
+            "TRUNCATECOLUMNS"
+          else
+            ""
+          end
 
-        "COPY #{table} FROM '#{fixed_objectpath}' CREDENTIALS '#{credentials}' REGION AS '#{config[:aws][:s3][:region]}' DELIMITER '#{EVENT_FIELD_SEPARATOR}' MAXERROR #{maxerror} EMPTYASNULL FILLRECORD TRUNCATECOLUMNS #{comprows} TIMEFORMAT 'auto' ACCEPTINVCHARS #{compression_format};"
+        "COPY #{table} FROM '#{fixed_objectpath}' CREDENTIALS '#{credentials}' REGION AS '#{config[:aws][:s3][:region]}' DELIMITER '#{EVENT_FIELD_SEPARATOR}' MAXERROR #{maxerror} EMPTYASNULL FILLRECORD #{truncate_columns} #{comprows} TIMEFORMAT 'auto' ACCEPTINVCHARS #{compression_format};"
       end
       module_function :build_copy_from_tsv_statement
 


### PR DESCRIPTION
Currently the storage-loader by default issues the Redshift COPY command with the TRUNCATECOLUMNS option. This option instructs Redshift to truncate column values which exceed the target columns specification. This pull request allows the truncation to be turned off on a per database/target basis.
