### PR TITLE
StorageLoader: Add skip_missing_jsonpaths option to simply ignore shredded events without a jsonpaths declaration

### DIFF
--- a/3-enrich/emr-etl-runner/config/config.yml.sample
+++ b/3-enrich/emr-etl-runner/config/config.yml.sample
@@ -55,6 +55,7 @@ enrich:
   continue_on_unexpected_error: false # Set to 'true' (and set :out_errors: above) if you don't want any exceptions thrown from ETL
   output_compression: NONE # Compression only supported with Redshift, set to NONE if you have Postgres targets. Allowed formats: NONE, GZIP
 storage:
+  skip_missing_jsonpaths: false # Set true to prevent to ignore importing an existing shredded event when no jsonpath is defined
   download:
     folder: # Postgres-only config option. Where to store the downloaded files. Leave blank for Redshift
   targets:

--- a/4-storage/storage-loader/lib/snowplow-storage-loader/redshift_loader.rb
+++ b/4-storage/storage-loader/lib/snowplow-storage-loader/redshift_loader.rb
@@ -112,15 +112,17 @@ module Snowplow
 
             jsonpaths_file = st.discover_jsonpaths_file(s3, config[:aws][:s3][:buckets][:jsonpath_assets])
             if jsonpaths_file.nil?
-              raise DatabaseLoadError, "Cannot find JSON Paths file to load #{st.s3_objectpath} into #{st.table}"
-            end
-
-            SqlStatements.new(
-              build_copy_from_json_statement(config, st.s3_objectpath, jsonpaths_file, st.table, target[:maxerror]),
-              build_analyze_statement(st.table),
-              build_vacuum_statement(st.table)
-            )
-          }
+              raise DatabaseLoadError, "Cannot find JSON Paths file to load #{st.s3_objectpath} into #{st.table}" unless config[:storage][:skip_missing_jsonpaths]
+              puts "INFO:  Skip loading #{st.table} because no jsonpath found on declared iglu repositories."
+              nil
+            else
+               SqlStatements.new(
+              	  build_copy_from_json_statement(config, st.s3_objectpath, jsonpaths_file, st.table, target[:maxerror]),
+              	  build_analyze_statement(st.table),
+              	  build_vacuum_statement(st.table)
+               )
+	    end
+          }.compact
         end
       end
       module_function :get_shredded_statements


### PR DESCRIPTION
Sometime it could be very useful to do now import all shredded events in database.
This `skip_missing_jsonpaths` option will simply help to ignore shredded events with no jsonpaths file declaration in iglu.

**Why ?**

Self Described Json are a really powerful concept. When you decided to adopt it, it could spread pretty quickly in all yours applications.

Here at Viadeo we have more than a thousand of custom events, in Mobile apps, event-sourced platform, and web front-ends. We have chosen Self Described Json as a standard to describe our events and to fire them with Snowplow Trackers.

But while we are pretty happy with that and happy to keep all those events into our S3 buckets, we do not want to create a Redshift Tables for each custom events.

With this new StorageLoader config option, the iglu jsonpaths file become optional for a custom event. If exists so the custom event will be imported in a dedicated Redshift table. If not, the custom event will simply be archived and not imported in a Redshift table.
