### PR TITLE
Scala Common Enrich: use only base MIME type in content-type check for SendGrid Adapter

### DIFF
--- a/3-enrich/emr-etl-runner/config/config.yml.sample
+++ b/3-enrich/emr-etl-runner/config/config.yml.sample
@@ -50,7 +50,7 @@ collectors:
 enrich:
   job_name: Snowplow ETL # Give your job a name
   versions:
-    hadoop_enrich: 1.5.0 # Version of the Hadoop Enrichment process
+    hadoop_enrich: 1.5.1 # Version of the Hadoop Enrichment process
     hadoop_shred: 0.6.0 # Version of the Hadoop Shredding process
     hadoop_elasticsearch: 0.1.0 # Version of the Hadoop to Elasticsearch copying process
   continue_on_unexpected_error: false # Set to 'true' (and set :out_errors: above) if you don't want any exceptions thrown from ETL

--- a/3-enrich/scala-common-enrich/project/BuildSettings.scala
+++ b/3-enrich/scala-common-enrich/project/BuildSettings.scala
@@ -21,7 +21,7 @@ object BuildSettings {
   // Basic settings for our app
   lazy val basicSettings = Seq[Setting[_]](
     organization          :=  "com.snowplowanalytics",
-    version               :=  "0.20.0",
+    version               :=  "0.20.1",
     description           :=  "Common functionality for enriching raw Snowplow events",
     scalaVersion          :=  "2.10.1",
     scalacOptions         :=  Seq("-deprecation", "-encoding", "utf8",

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/SendgridAdapter.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/SendgridAdapter.scala
@@ -37,6 +37,11 @@ import com.snowplowanalytics.iglu.client.{Resolver, SchemaKey}
 import com.snowplowanalytics.snowplow.enrich.common.loaders.CollectorPayload
 import com.snowplowanalytics.snowplow.enrich.common.utils.{JsonUtils => JU}
 
+import javax.mail.internet.ContentType
+
+import scala.util.Try
+
+
 /**
  * Transforms a collector payload which conforms to
  * a known version of the Sendgrid Tracking webhook
@@ -134,7 +139,7 @@ object SendgridAdapter extends Adapter {
     (payload.body, payload.contentType) match {
       case (None, _) => s"Request body is empty: no ${VendorName} event to process".failNel
       case (_, None) => s"Request body provided but content type empty, expected ${ContentType} for ${VendorName}".failNel
-      case (_, Some(ct)) if ct != ContentType => s"Content type of ${ct} provided, expected ${ContentType} for ${VendorName}".failNel
+      case (_, Some(ct)) if Try(new ContentType(ct).getBaseType).getOrElse(ct) != ContentType => s"Content type of ${ct} provided, expected ${ContentType} for ${VendorName}".failNel
       case (Some(body), _) => {
         val events = payloadBodyToEvents(body, payload)
         rawEventsListProcessor(events)

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/SendgridAdapterSpec.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/SendgridAdapterSpec.scala
@@ -224,13 +224,18 @@ class SendgridAdapterSpec extends Specification with ValidationMatchers {
     "reject empty content type" in {
       val invalidpayload = CollectorPayload(Shared.api, Nil, None, samplePostPayload.some, Shared.cljSource, Shared.context)
       val toBeRejected = SendgridAdapter.toRawEvents(invalidpayload)
-
       toBeRejected must beFailing
     }
 
     "reject unexpected content type" in {
       val invalidpayload = CollectorPayload(Shared.api, Nil, "invalidtype/invalid".some, samplePostPayload.some, Shared.cljSource, Shared.context)
       SendgridAdapter.toRawEvents(invalidpayload) must beFailing
+    }
+
+    "accept content types with explicit charsets" in {
+      val payload = CollectorPayload(Shared.api, Nil, "application/json; charset=utf-8".some, samplePostPayload.some, Shared.cljSource, Shared.context)
+      val res = SendgridAdapter.toRawEvents(payload)
+      res must beSuccessful
     }
 
     "reject unsupported event types" in {

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/miscEnrichmentSpecs.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/miscEnrichmentSpecs.scala
@@ -37,7 +37,7 @@ class EtlVersionSpec extends MutSpecification {
 
   "The ETL version" should {
     "be successfully returned" in {
-      MiscEnrichments.etlVersion("hadoop-x.x.x") must_== "hadoop-x.x.x-common-0.20.0"
+      MiscEnrichments.etlVersion("hadoop-x.x.x") must_== "hadoop-x.x.x-common-0.20.1"
     }
   }
 }

--- a/3-enrich/scala-hadoop-enrich/project/BuildSettings.scala
+++ b/3-enrich/scala-hadoop-enrich/project/BuildSettings.scala
@@ -20,7 +20,7 @@ object BuildSettings {
   // Basic settings for our app
   lazy val basicSettings = Seq[Setting[_]](
     organization  := "com.snowplowanalytics",
-    version       := "1.5.0",
+    version       := "1.5.1",
     description   := "The Snowplow Hadoop Enrichment process, written in Scalding for Hadoop 2.4",
     scalaVersion  := "2.10.4",
     scalacOptions := Seq("-deprecation", "-encoding", "utf8",

--- a/3-enrich/scala-hadoop-enrich/project/Dependencies.scala
+++ b/3-enrich/scala-hadoop-enrich/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
     // Scala
     val scalding         = "0.11.2"
     val scalaz7          = "7.0.0"
-    val commonEnrich     = "0.20.0"
+    val commonEnrich     = "0.20.1"
     val igluClient       = "0.3.1"
     // Scala (test only)
     val specs2           = "1.14"

--- a/3-enrich/scala-hadoop-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.hadoop/JobSpecHelpers.scala
+++ b/3-enrich/scala-hadoop-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.hadoop/JobSpecHelpers.scala
@@ -56,7 +56,7 @@ object JobSpecHelpers {
   /**
    * The current version of our Hadoop ETL
    */
-  val EtlVersion = "hadoop-1.5.0-common-0.20.0"
+  val EtlVersion = "hadoop-1.5.0-common-0.20.1"
 
   val EtlTimestamp = "2001-09-09 01:46:40.000"
 

--- a/3-enrich/scala-hadoop-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.hadoop/JobSpecHelpers.scala
+++ b/3-enrich/scala-hadoop-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.hadoop/JobSpecHelpers.scala
@@ -56,7 +56,7 @@ object JobSpecHelpers {
   /**
    * The current version of our Hadoop ETL
    */
-  val EtlVersion = "hadoop-1.5.0-common-0.20.1"
+  val EtlVersion = "hadoop-1.5.1-common-0.20.1"
 
   val EtlTimestamp = "2001-09-09 01:46:40.000"
 


### PR DESCRIPTION
fix for #2328