### PR TITLE
Scala Stream Collector: configurable cookie path

### DIFF
--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ResponseHandler.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ResponseHandler.scala
@@ -156,7 +156,8 @@ class ResponseHandler(config: CollectorConfig, sinks: CollectorSinks)(implicit c
         val responseCookie = HttpCookie(
           "sp", networkUserId,
           expires=Some(DateTime.now+config.cookieExpiration),
-          domain=config.cookieDomain
+          domain=config.cookieDomain,
+          path=Some("/")
         )
         `Set-Cookie`(responseCookie) :: headersWithoutCookie
       } else {

--- a/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
+++ b/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
@@ -132,6 +132,7 @@ collector {
         val httpCookie = httpCookies(0)
 
         httpCookie.name must be("sp")
+        httpCookie.path must beSome("/")
         httpCookie.domain must beSome
         httpCookie.domain.get must be(collectorConfig.cookieDomain.get)
         httpCookie.expires must beSome

--- a/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/PostSpec.scala
+++ b/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/PostSpec.scala
@@ -127,6 +127,7 @@ collector {
         val httpCookie = httpCookies(0)
 
         httpCookie.name must be("sp")
+        httpCookie.path must beSome("/")
         httpCookie.domain must beSome
         httpCookie.domain.get must be(collectorConfig.cookieDomain.get)
         httpCookie.expires must beSome


### PR DESCRIPTION
Hardwire the cookie path to / to make sure it also is valid for nested urls like click track.

This solves #2524 