### PR TITLE
EmrEtlRunner: rescue the intermittent RestClient::SSLCertificateNotVerified error

### DIFF
--- a/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/emr_job.rb
+++ b/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/emr_job.rb
@@ -554,6 +554,9 @@ module Snowplow
           rescue IOError => ioe
             logger.warn "Got IOError #{ioe}, waiting 5 minutes before checking jobflow again"
             sleep(300)
+          rescue RestClient::SSLCertificateNotVerified => sce
+            logger.warn "Got RestClient::SSSLCertificateNotVerified #{sce}, waiting 5 minutes before checking jobflow again"
+            sleep(300)
           end
         end
 


### PR DESCRIPTION
It happened recently that emr-etl-runner failed b/c of this exception:
`RestClient::SSLCertificateNotVerified`, but EMR job has finished successfully.

Log:

```
D, [2016-03-31T12:02:11.004000 #15530] DEBUG -- : EMR jobflow
j-3LKT4G4XSB2PW started, waiting for jobflow to complete...
F, [2016-03-31T12:06:11.276000 #15530] FATAL -- :

RestClient::SSLCertificateNotVerified (certificate verify failed):
  ...!/gems/rest-client-1.8.0/lib/restclient/request.rb:445:in `transmit'
  .../gems/rest-client-1.8.0/lib/restclient/request.rb:176:in `execute'
  .../gems/rest-client-1.8.0/lib/restclient/request.rb:41:in `execute'
  .../gems/rest-client-1.8.0/lib/restclient.rb:69:in `post'
  .../gems/elasticity-6.0.3/lib/elasticity/aws_session.rb:30:in `submit'
  .../gems/elasticity-6.0.3/lib/elasticity/emr.rb:206:in `list_steps'
  .../gems/elasticity-6.0.3/lib/elasticity/job_flow.rb:162:in `cluster_step_status'
  .../emr-etl-runner/lib/snowplow-emr-etl-runner/emr_job.rb:419:in `wait_for'
```
