### PR TITLE
Scala Common Enrich: BrowserLanguageEnrichment

### DIFF
--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EnrichmentManager.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EnrichmentManager.scala
@@ -462,6 +462,12 @@ object EnrichmentManager {
       case None => None.success
     }
 
+    // Execute browser language enrichment
+    Option(event.br_lang).map(browser_language => event.br_lang = registry.getBrowserLanguageEnrichment match {
+      case Some(ble) => ble.convertBrowserLanguage(browser_language)
+      case None => browser_language
+    })
+
     // Assemble array of derived contexts
     val derived_contexts = List(uaParser).collect {
       case Success(Some(context)) => context

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EnrichmentRegistry.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/EnrichmentRegistry.scala
@@ -50,13 +50,15 @@ import registry.{
   EventFingerprintEnrichment,
   CookieExtractorEnrichment,
   WeatherEnrichment,
+  BrowserLanguageEnrichment,
   UserAgentUtilsEnrichmentConfig,
   UaParserEnrichmentConfig,
   CurrencyConversionEnrichmentConfig,
   JavascriptScriptEnrichmentConfig,
   EventFingerprintEnrichmentConfig,
   CookieExtractorEnrichmentConfig,
-  WeatherEnrichmentConfig
+  WeatherEnrichmentConfig,
+  BrowserLanguageEnrichmentConfig
 }
 
 import utils.ScalazJson4sUtils
@@ -154,6 +156,8 @@ object EnrichmentRegistry {
             CookieExtractorEnrichmentConfig.parse(enrichmentConfig, schemaKey).map((nm, _).some)
           } else if (nm == "weather_enrichment_config") {
             WeatherEnrichmentConfig.parse(enrichmentConfig, schemaKey).map((nm, _).some)
+          } else if (nm == "browser_language_config") {
+            BrowserLanguageEnrichmentConfig.parse(enrichmentConfig, schemaKey).map((nm, _).some)
           } else {
             None.success // Enrichment is not recognized yet
           }
@@ -276,6 +280,15 @@ case class EnrichmentRegistry(private val configs: EnrichmentMap) {
    */
   def getWeatherEnrichment: Option[WeatherEnrichment] =
     getEnrichment[WeatherEnrichment]("weather_enrichment_config")
+
+  /*
+   * Returns an Option boxing the BrowserLanguageEnrichment
+   * config value if present, or None if not
+   *
+   * @return Option boxing the BrowserLanguageEnrichment instance
+   */
+  def getBrowserLanguageEnrichment: Option[BrowserLanguageEnrichment.type] =
+    getEnrichment[BrowserLanguageEnrichment.type]("browser_language_config")
 
   /**
    * Returns an Option boxing an Enrichment

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/BrowserLanguageEnrichment.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/BrowserLanguageEnrichment.scala
@@ -1,0 +1,64 @@
+package com.snowplowanalytics
+package snowplow
+package enrich
+package common
+package enrichments
+package registry
+
+// Java
+import java.util.Locale
+
+// Maven Artifact
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion
+
+// Scalaz
+import scalaz._
+import Scalaz._
+
+// json4s
+import org.json4s.JValue
+
+// Iglu
+import iglu.client.{
+  SchemaCriterion,
+  SchemaKey
+}
+import iglu.client.validation.ProcessingMessageMethods._
+
+// This project
+import utils.ScalazJson4sUtils
+
+/**
+* Companion object. Lets us create a BrowserLanguageEnrichment
+* from a JValue.
+*/
+object BrowserLanguageEnrichmentConfig extends ParseableEnrichment {
+
+  val supportedSchema = SchemaCriterion("com.snowplowanalytics.snowplow", "browser_language_config", "jsonschema", 1, 0)
+
+  /**
+   * Creates an BrowserLanguageEnrichment instance from a JValue.
+   *
+   * @param config The browser_language enrichment JSON
+   * @param schemaKey The SchemaKey provided for the enrichment
+   *        Must be a supported SchemaKey for this enrichment
+   * @return a configured BrowserLanguageEnrichment instance
+   */
+  def parse(config: JValue, schemaKey: SchemaKey): ValidatedNelMessage[BrowserLanguageEnrichment.type] =
+    isParseable(config, schemaKey).map(_ => BrowserLanguageEnrichment)
+}
+
+/**
+ * Config for an browser_language enrichment
+ *
+ * @param browser_language The language string received from the browser
+ * @return a language for display
+ */
+case object BrowserLanguageEnrichment extends Enrichment {
+  val version = new DefaultArtifactVersion("0.1.0")
+
+  def convertBrowserLanguage(browser_language: String): String = {
+    val locale = Locale.forLanguageTag(browser_language)
+    return locale.getDisplayLanguage()
+  }
+}

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/BrowserLanguageEnrichmentSpec.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/BrowserLanguageEnrichmentSpec.scala
@@ -1,0 +1,34 @@
+package com.snowplowanalytics.snowplow.enrich.common
+package enrichments
+package registry
+
+// Specs2
+import org.specs2.Specification
+import org.specs2.matcher.DataTables
+
+/**
+ * Tests the convertBrowserLanguage function
+ */
+class BrowserLanguageEnrichmentSpec extends Specification with DataTables {
+
+  def is =
+    "Converting browser language across a variety of languages should work"     ! e1
+
+  def e1 =
+    "SPEC NAME"              || "BROWSER LANG"          | "EXPECTED OUTPUT"     |
+    "none"                   !! ""                      ! ""                    |
+    "english"                !! "en"                    ! "English"             |
+    "english US"             !! "en-US"                 ! "English"             |
+    "english GB"             !! "en-GB"                 ! "English"             |
+    "english ZA"             !! "en-ZA"                 ! "English"             |
+    "english us"             !! "en-us"                 ! "English"             |
+    "french"                 !! "fr"                    ! "French"              |
+    "french FR"              !! "fr-FR"                 ! "French"              |
+    "russian"                !! "ru"                    ! "Russian"             |
+    "chinese cn"             !! "zh-cn"                 ! "Chinese"             |
+    "german"                 !! "de"                    ! "German"              |> {
+      (_, browser_language, expected) => {
+        BrowserLanguageEnrichment.convertBrowserLanguage(browser_language) must_== expected
+      }
+    }
+}


### PR DESCRIPTION
This adds an enrichment to convert the browser language for an event into a human readable format. E.g. `en-US` becomes `English`, `zh-cn` becomes `Chinese`.
