### PR TITLE
Adding support for POST JSON payloads in IgluAdapter

### DIFF
--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/Adapter.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/Adapter.scala
@@ -37,6 +37,7 @@ import Scalaz._
 import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
+import com.fasterxml.jackson.core.JsonParseException
 
 // This project
 import loaders.CollectorPayload
@@ -371,4 +372,23 @@ trait Adapter {
         }
       }
     }
+
+  /**
+   * Attempts to parse a json string into a JValue
+   * example: {"p":"app"} becomes JObject(List((p,JString(app))))
+   *
+   * @param jsonStr The string we want to parse into a JValue
+   * @return a Validated JValue or a NonEmptyList Failure
+   *         containing a JsonParseException
+   */
+  private[registry] def parseJsonSafe(jsonStr: String): Validated[JValue] =
+    try {
+      parse(jsonStr).successNel
+    } catch {
+      case e: JsonParseException => {
+        val exception = JU.stripInstanceEtc(e.toString).orNull
+        s"Event failed to parse into JSON: [${exception}]".failNel
+      }
+    }
+
 }

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/IgluAdapterSpec.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/IgluAdapterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2014 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2012-2016 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -21,6 +21,9 @@ import org.joda.time.DateTime
 import scalaz._
 import Scalaz._
 
+// json4s
+import org.json4s._
+
 // Snowplow
 import loaders.{
   CollectorApi,
@@ -39,7 +42,7 @@ import org.specs2.scalaz.ValidationMatchers
 class IgluAdapterSpec extends Specification with DataTables with ValidationMatchers with ScalaCheck { def is =
 
   "This is a specification to test the IgluAdapter functionality"                                                            ^
-                                                                                                                            p^
+                                                                                                                             p^
   "toRawEvents should return a NEL containing one RawEvent if the CloudFront querystring is minimally populated"             ! e1^
   "toRawEvents should return a NEL containing one RawEvent if the CloudFront querystring is maximally populated"             ! e2^
   "toRawEvents should return a NEL containing one RawEvent if the Clojure-Tomcat querystring is populated"                   ! e3^
@@ -47,7 +50,13 @@ class IgluAdapterSpec extends Specification with DataTables with ValidationMatch
   "toRawEvents should return a Validation Failure if there are no parameters on the CloudFront querystring"                  ! e5^
   "toRawEvents should return a Validation Failure if there is no schema parameter on the CloudFront querystring"             ! e6^
   "toRawEvents should return a Validation Failure if the schema parameter is not in an Iglu-compatible format"               ! e7^
-                                                                                                                             end
+  "parseJSON should return validated JSON object when parsing a valid JSON payload"                                          ! e8^
+  "parseJSON should return a Validation Failure on an invalid JSON payload"                                                  ! e9^
+  "toRawEvents should return a NEL containing one RawEvent if the schema parameter is populated with a valid content type"   ! e10^
+  "toRawEvents should return a Validation Failure if an unsupported content type is specified"                               ! e11^
+  "toRawEvents should return a Validation Failure if there are no events in the JSON payload"                                ! e12^
+  "toRawEvents should return a Validation Failure if body is specified but a content type is not provided"                   ! e13^
+  end
 
   implicit val resolver = SpecHelpers.IgluResolver
 
@@ -231,4 +240,73 @@ class IgluAdapterSpec extends Specification with DataTables with ValidationMatch
 
     actual must beFailing(NonEmptyList("iglooooooo://blah is not a valid Iglu-format schema URI"))
   }
+
+  def e8 = {
+    val jsonStr = """{"key":"value"}"""
+    val expected = JObject(List(("key",JString("value"))))
+    IgluAdapter.parseJson(jsonStr) must beSuccessful(expected)
+  }
+
+  def e9 = {
+    val jsonStr = """{"key":value"}"""
+    val expected = "Iglu event failed to parse into JSON: [com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'value': was expecting ('true', 'false' or 'null') at [Source: java.io.StringReader@xxxxxx; line: 1, column: 13]]"
+    IgluAdapter.parseJson(jsonStr) must beFailing(NonEmptyList(expected))
+  }
+
+  def e10 = {
+    val params = toNameValuePairs(
+      "schema"         -> "iglu:com.acme/campaign/jsonschema/1-0-1",
+      "some_param"     -> "foo",
+      "p"              -> "mob"
+      )
+    val jsonStr = """{"key":"value", "everwets":"processed"}"""
+    val payload = CollectorPayload(Shared.api, params, "application/json".some, jsonStr.some, Shared.cljSource, Shared.context)
+    val actual = IgluAdapter.toRawEvents(payload)
+
+    val expected = RawEvent(Shared.api,Map("tv" -> "com.snowplowanalytics.iglu-v1", "e" -> "ue", "p" -> "mob",
+      "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.acme/campaign/jsonschema/1-0-1","data":{"key":"value","everwets":"processed"}}}"""),
+      "application/json".some,Shared.cljSource,Shared.context)
+
+    actual must beSuccessful(NonEmptyList(expected))
+  }
+
+  def e11 = {
+    val params = toNameValuePairs(
+      "schema"         -> "iglu:com.acme/campaign/jsonschema/1-0-1",
+      "some_param"     -> "foo",
+      "p"              -> "mob"
+      )
+    val jsonStr = """{"key":"value", "everwets":"processed"}"""
+    val payload = CollectorPayload(Shared.api, params, "application/badtype".some, jsonStr.some, Shared.cljSource, Shared.context)
+    val actual = IgluAdapter.toRawEvents(payload)
+
+    actual must beFailing(NonEmptyList("Content type not supported"))
+  }
+
+  def e12 = {
+    val params = toNameValuePairs(
+      "schema"         -> "iglu:com.acme/campaign/jsonschema/1-0-1",
+      "some_param"     -> "foo",
+      "p"              -> "mob"
+      )
+    val jsonStr = """{}"""
+    val payload = CollectorPayload(Shared.api, params, "application/json".some, jsonStr.some, Shared.cljSource, Shared.context)
+    val actual = IgluAdapter.toRawEvents(payload)
+
+    actual must beFailing(NonEmptyList("Iglu event failed json sanity check: has no events"))
+  }
+
+  def e13 = {
+    val params = toNameValuePairs(
+      "schema"         -> "iglu:com.acme/campaign/jsonschema/1-0-1",
+      "some_param"     -> "foo",
+      "p"              -> "mob"
+      )
+    val jsonStr = """{"key":"value"}"""
+    val payload = CollectorPayload(Shared.api, params, None, jsonStr.some, Shared.cljSource, Shared.context)
+    val actual = IgluAdapter.toRawEvents(payload)
+
+    actual must beFailing(NonEmptyList("Content type has not been specified"))
+  }
+
 }

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/IgluAdapterSpec.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/IgluAdapterSpec.scala
@@ -50,12 +50,10 @@ class IgluAdapterSpec extends Specification with DataTables with ValidationMatch
   "toRawEvents should return a Validation Failure if there are no parameters on the CloudFront querystring"                  ! e5^
   "toRawEvents should return a Validation Failure if there is no schema parameter on the CloudFront querystring"             ! e6^
   "toRawEvents should return a Validation Failure if the schema parameter is not in an Iglu-compatible format"               ! e7^
-  "parseJSON should return validated JSON object when parsing a valid JSON payload"                                          ! e8^
-  "parseJSON should return a Validation Failure on an invalid JSON payload"                                                  ! e9^
-  "toRawEvents should return a NEL containing one RawEvent if the schema parameter is populated with a valid content type"   ! e10^
-  "toRawEvents should return a Validation Failure if an unsupported content type is specified"                               ! e11^
-  "toRawEvents should return a Validation Failure if there are no events in the JSON payload"                                ! e12^
-  "toRawEvents should return a Validation Failure if body is specified but a content type is not provided"                   ! e13^
+  "toRawEvents should return a NEL containing one RawEvent if the schema parameter is populated with a valid content type"   ! e8^
+  "toRawEvents should return a Validation Failure if an unsupported content type is specified"                               ! e9^
+  "toRawEvents should return a Validation Failure if there are no events in the JSON payload"                                ! e10^
+  "toRawEvents should return a Validation Failure if body is specified but a content type is not provided"                   ! e11^
   end
 
   implicit val resolver = SpecHelpers.IgluResolver
@@ -118,10 +116,10 @@ class IgluAdapterSpec extends Specification with DataTables with ValidationMatch
       "tracking_id"    -> "3353af9c-e298-2cf3-9f1c-b377a9c84dad",
       "ad_unit"        -> "UN-11-b",
       "aid"            -> "webhooks"
-      )    
+      )
     val payload = CollectorPayload(Shared.api, params, None, None, Shared.cfSource, Shared.context)
     val actual = IgluAdapter.toRawEvents(payload)
-    
+
     val expectedMap = {
       val json =
         """|{
@@ -160,7 +158,7 @@ class IgluAdapterSpec extends Specification with DataTables with ValidationMatch
       )
     val payload = CollectorPayload(Shared.api, params, None, None, Shared.cljSource, Shared.context)
     val actual = IgluAdapter.toRawEvents(payload)
-    
+
     val expectedMap = {
       val json =
         """|{
@@ -242,18 +240,6 @@ class IgluAdapterSpec extends Specification with DataTables with ValidationMatch
   }
 
   def e8 = {
-    val jsonStr = """{"key":"value"}"""
-    val expected = JObject(List(("key",JString("value"))))
-    IgluAdapter.parseJson(jsonStr) must beSuccessful(expected)
-  }
-
-  def e9 = {
-    val jsonStr = """{"key":value"}"""
-    val expected = "Iglu event failed to parse into JSON: [com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'value': was expecting ('true', 'false' or 'null') at [Source: java.io.StringReader@xxxxxx; line: 1, column: 13]]"
-    IgluAdapter.parseJson(jsonStr) must beFailing(NonEmptyList(expected))
-  }
-
-  def e10 = {
     val params = toNameValuePairs(
       "schema"         -> "iglu:com.acme/campaign/jsonschema/1-0-1",
       "some_param"     -> "foo",
@@ -270,7 +256,7 @@ class IgluAdapterSpec extends Specification with DataTables with ValidationMatch
     actual must beSuccessful(NonEmptyList(expected))
   }
 
-  def e11 = {
+  def e9 = {
     val params = toNameValuePairs(
       "schema"         -> "iglu:com.acme/campaign/jsonschema/1-0-1",
       "some_param"     -> "foo",
@@ -283,7 +269,7 @@ class IgluAdapterSpec extends Specification with DataTables with ValidationMatch
     actual must beFailing(NonEmptyList("Content type not supported"))
   }
 
-  def e12 = {
+  def e10 = {
     val params = toNameValuePairs(
       "schema"         -> "iglu:com.acme/campaign/jsonschema/1-0-1",
       "some_param"     -> "foo",
@@ -296,7 +282,7 @@ class IgluAdapterSpec extends Specification with DataTables with ValidationMatch
     actual must beFailing(NonEmptyList("Iglu event failed json sanity check: has no events"))
   }
 
-  def e13 = {
+  def e11 = {
     val params = toNameValuePairs(
       "schema"         -> "iglu:com.acme/campaign/jsonschema/1-0-1",
       "some_param"     -> "foo",


### PR DESCRIPTION
RFC for allowing POST requests to the Iglu webhook endpoint using JSON