### PR TITLE
Add support for cookie bounce #2697

### DIFF
--- a/2-collectors/scala-stream-collector/examples/config.hocon.sample
+++ b/2-collectors/scala-stream-collector/examples/config.hocon.sample
@@ -28,6 +28,19 @@ collector {
   # records stored in the current stream.
   production = true
 
+  # Defines whether the "No-third party cookie check" should be perfomed.
+  # If this parameter is not specified, it defaults to false.
+  # This  will create an auto-redirect to itself  with `third-party-cookie-param`
+  # if set to true.
+  third-party-redirect-enabled = false
+
+  # The name of the request parameter which will be used on redirect if 'third-party-redirect-enabled'
+  # is set to true.
+  third-party-cookie-param = "n3pc"
+
+  #The network id which will be set in case the 3rd party cookie was not set.
+  fallback-network-id = "00000000-0000-4000-A000-000000000000"
+
   # Configure the P3P policy header.
   p3p {
     policyref = "/w3c/p3p.xml"

--- a/2-collectors/scala-stream-collector/project/Dependencies.scala
+++ b/2-collectors/scala-stream-collector/project/Dependencies.scala
@@ -50,6 +50,7 @@ object Dependencies {
     // Using the newest version of spec (2.3.6) causes
     // conflicts with `spray` for `com.chuusai.shapeless`
     val specs2           = "2.2.3"
+    val mockito          = "1.9.5"
   }
 
   object Libraries {
@@ -77,6 +78,7 @@ object Dependencies {
     val json4sJackson    = "org.json4s"            %% "json4s-jackson"            % V.json4s
 
     // Scala (test only)
+    val mockito          = "org.mockito"           %  "mockito-all"               % V.mockito  % "test"
     val specs2           = "org.specs2"            %% "specs2"                    % V.specs2   % "test"
     val sprayTestkit     = "io.spray"              %% "spray-testkit"             % V.spray    % "test"
   }

--- a/2-collectors/scala-stream-collector/project/ScalaCollectorBuild.scala
+++ b/2-collectors/scala-stream-collector/project/ScalaCollectorBuild.scala
@@ -50,7 +50,8 @@ object ScalaCollectorBuild extends Build {
         Libraries.scalaz7,
         Libraries.snowplowRawEvent,
         Libraries.collectorPayload,
-        Libraries.json4sJackson
+        Libraries.json4sJackson,
+        Libraries.mockito
       )
     )
 }

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ScalaCollectorApp.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ScalaCollectorApp.scala
@@ -125,11 +125,11 @@ object ScalaCollector extends App {
 // Return Options from the configuration.
 object Helper {
   implicit class RichConfig(val underlying: Config) extends AnyVal {
-    def getOptionalString(path: String): Option[String] = try {
-      Some(underlying.getString(path))
-    } catch {
-      case e: ConfigException.Missing => None
-    }
+    def catchMissing = util.control.Exception.catching(classOf[ConfigException.Missing])
+
+    def getOptionalString(path: String): Option[String] = catchMissing opt underlying.getString(path)
+
+    def getOptionalBoolean(path: String): Option[Boolean] = catchMissing opt underlying.getBoolean(path)
   }
 }
 
@@ -153,6 +153,11 @@ class CollectorConfig(config: Config) {
   val interface = collector.getString("interface")
   val port = collector.getInt("port")
   val production = collector.getBoolean("production")
+
+  //Third party cookie config params.
+  val n3pcRedirectEnabled = collector.getOptionalBoolean("third-party-redirect-enabled").getOrElse(false)
+  val thirdPartyCookiesParameter = collector.getOptionalString("third-party-cookie-param").getOrElse("n3pc")
+  val fallbackNetworkUserId = collector.getOptionalString("fallback-network-id").getOrElse("00000000-0000-4000-A000-000000000000")
 
   private val p3p = collector.getConfig("p3p")
   val p3pPolicyRef = p3p.getString("policyref")

--- a/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
+++ b/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
@@ -17,6 +17,9 @@ package collectors
 package scalastream
 
 // Scala
+import org.specs2.mock.Mockito
+import spray.http.{Rendering, StatusCodes}
+
 import scala.collection.mutable.MutableList
 
 // Akka
@@ -25,20 +28,14 @@ import akka.actor.{ActorSystem, Props}
 // Specs2 and Spray testing
 import org.specs2.matcher.AnyMatchers
 import org.specs2.mutable.Specification
-import org.specs2.specification.{Scope,Fragments}
 import spray.testkit.Specs2RouteTest
 
 // Spray
 import spray.http.{DateTime,HttpHeader,HttpRequest,HttpCookie,RemoteAddress}
-import spray.http.HttpHeaders.{
-  Cookie,
-  `Set-Cookie`,
-  `Remote-Address`,
-  `Raw-Request-URI`
-}
+import spray.http.HttpHeaders._
 
 // Config
-import com.typesafe.config.{ConfigFactory,Config,ConfigException}
+import com.typesafe.config.{ConfigFactory,Config}
 
 // Thrift
 import org.apache.thrift.TDeserializer
@@ -47,15 +44,17 @@ import org.apache.thrift.TDeserializer
 import sinks._
 import CollectorPayload.thrift.model1.CollectorPayload
 
-class CollectorServiceSpec extends Specification with Specs2RouteTest with
+class CollectorServiceSpec extends Specification with Specs2RouteTest with Mockito with
      AnyMatchers {
-   val testConf: Config = ConfigFactory.parseString("""
+
+
+   def testConf(n3pcEnabled: Boolean): Config = ConfigFactory.parseString(s"""
 collector {
   interface = "0.0.0.0"
   port = 8080
 
   production = true
-
+  third-party-redirect-enabled = $n3pcEnabled
   p3p {
     policyref = "/w3c/p3p.xml"
     CP = "NOI DSP COR NID PSA OUR IND COM NAV STA"
@@ -94,28 +93,299 @@ collector {
   }
 }
 """)
-  val collectorConfig = new CollectorConfig(testConf)
-  val sink = new TestSink
-  val sinks = CollectorSinks(sink, sink)
-  val responseHandler = new ResponseHandler(collectorConfig, sinks)
-  val collectorService = new CollectorService(collectorConfig, responseHandler, system)
-  val thriftDeserializer = new TDeserializer
 
-  // By default, spray will always add Remote-Address to every request
-  // when running with the `spray.can.server.remote-address-header`
-  // option. However, the testing does not read this option and a
-  // remote address always needs to be set.
-  def CollectorGet(uri: String, cookie: Option[`HttpCookie`] = None,
-      remoteAddr: String = "127.0.0.1") = {
-    val headers: MutableList[HttpHeader] =
-      MutableList(`Remote-Address`(remoteAddr),`Raw-Request-URI`(uri))
-    cookie.foreach(headers += `Cookie`(_))
-    Get(uri).withHeaders(headers.toList)
+  "Snowplow's Scala collector with n3pc redirect " should {
+    val collectorConfig = new CollectorConfig(testConf(n3pcEnabled = true))
+
+    // By default, spray will always add Remote-Address to every request
+    // when running with the `spray.can.server.remote-address-header`
+    // option. However, the testing does not read this option and a
+    // remote address always needs to be set.
+    def CollectorGet(uri: String, cookie: Option[`HttpCookie`] = None,
+                     remoteAddr: String = "127.0.0.1", additionalHeaders: List[HttpHeader] = List()) = {
+      val headers: MutableList[HttpHeader] =
+        MutableList(`Remote-Address`(remoteAddr),`Raw-Request-URI`(uri)) ++ additionalHeaders
+      cookie.foreach(headers += `Cookie`(_))
+      Get(uri).withHeaders(headers.toList)
+    }
+    "return a redirect with n3pc parameter while keeping request params and using original site schema" in {
+      val sink = smartMock[AbstractSink]
+      sink.storeRawEvents(any[List[Array[Byte]]], anyString).answers{(params, mock) => params match {
+        case Array(firstArg, secondArg) => firstArg.asInstanceOf[List[Array[Byte]]]
+      }
+      }
+      val sinks = CollectorSinks(sink, sink)
+      val responseHandler = new ResponseHandler(collectorConfig, sinks)
+      val collectorService = new CollectorService(collectorConfig, responseHandler, system)
+      val originalUrl = "/i?uid=someUid&cx=someCx&url=https://example.com/something"
+      CollectorGet(originalUrl) ~> collectorService.collectorRoute ~> check {
+        response.status.mustEqual(StatusCodes.Found)
+        //we're redirecting so we should not save anything to kinesis
+        there was no(sink).storeRawEvents(any, any)
+        val locationHeader: String = header("Location").get.value
+        val httpCookies: List[HttpCookie] = headers.collect {
+          case `Set-Cookie`(hc) => hc
+        }
+        locationHeader must beEqualTo(s"https://example.com$originalUrl&${collectorConfig.thirdPartyCookiesParameter}=true")
+        locationHeader must contain(collectorConfig.thirdPartyCookiesParameter)
+        //a cookie must be sent back
+        httpCookies must not be empty
+      }
+    }
+
+    "return a redirect with n3pc parameter with protocol from X-Forwarded-Proto" in {
+      val sink = smartMock[AbstractSink]
+
+      sink.storeRawEvents(any[List[Array[Byte]]], anyString).answers{(params, mock) => params match {
+        case Array(firstArg, secondArg) => firstArg.asInstanceOf[List[Array[Byte]]]
+      }
+      }
+      val sinks = CollectorSinks(sink, sink)
+      val responseHandler = new ResponseHandler(collectorConfig, sinks)
+      val collectorService = new CollectorService(collectorConfig, responseHandler, system)
+      val originalUrl = "/i?uid=someUid&cx=someCx"
+      CollectorGet(originalUrl, additionalHeaders = List(RawHeader("X-Forwarded-Proto", "https"))) ~> collectorService.collectorRoute ~> check {
+        response.status.mustEqual(StatusCodes.Found)
+        //we're redirecting so we should not save anything to kinesis
+        there was no(sink).storeRawEvents(any, any)
+        val locationHeader: String = header("Location").get.value
+        val httpCookies: List[HttpCookie] = headers.collect {
+          case `Set-Cookie`(hc) => hc
+        }
+        locationHeader must beEqualTo(s"https://example.com$originalUrl&${collectorConfig.thirdPartyCookiesParameter}=true")
+        locationHeader must contain(collectorConfig.thirdPartyCookiesParameter)
+        //a cookie must be sent back
+        httpCookies must not be empty
+      }
+    }
+
+    "return a redirect with n3pc parameter while keeping request params" in {
+      val sink = smartMock[AbstractSink]
+      sink.storeRawEvents(any[List[Array[Byte]]], anyString).answers{(params, mock) => params match {
+        case Array(firstArg, secondArg) => firstArg.asInstanceOf[List[Array[Byte]]]
+      }
+      }
+      val sinks = CollectorSinks(sink, sink)
+      val responseHandler = new ResponseHandler(collectorConfig, sinks)
+      val collectorService = new CollectorService(collectorConfig, responseHandler, system)
+      val originalUrl = "/i?uid=someUid&cx=someCx"
+      CollectorGet(originalUrl) ~> collectorService.collectorRoute ~> check {
+        response.status.mustEqual(StatusCodes.Found)
+        //we're redirecting so we should not save anything to kinesis
+        there was no(sink).storeRawEvents(any, any)
+        val locationHeader: String = header("Location").get.value
+        val httpCookies: List[HttpCookie] = headers.collect {
+          case `Set-Cookie`(hc) => hc
+        }
+        locationHeader must beEqualTo(s"http://example.com$originalUrl&${collectorConfig.thirdPartyCookiesParameter}=true")
+        locationHeader must contain(collectorConfig.thirdPartyCookiesParameter)
+        //a cookie must be sent back
+        httpCookies must not be empty
+      }
+    }
+
+    "return a redirect with n3pc parameter " in {
+      val sink = smartMock[AbstractSink]
+      sink.storeRawEvents(any[List[Array[Byte]]], anyString).answers{(params, mock) => params match {
+          case Array(firstArg, secondArg) => firstArg.asInstanceOf[List[Array[Byte]]]
+        }
+      }
+      val sinks = CollectorSinks(sink, sink)
+      val responseHandler = new ResponseHandler(collectorConfig, sinks)
+      val collectorService = new CollectorService(collectorConfig, responseHandler, system)
+
+      CollectorGet("/i") ~> collectorService.collectorRoute ~> check {
+        response.status.mustEqual(StatusCodes.Found)
+        there was no(sink).storeRawEvents(any, any)
+        val locationHeader: String = header("Location").get.value
+        locationHeader must contain(collectorConfig.thirdPartyCookiesParameter)
+      }
+    }
+
+    "set the fallback cookie value after calling it with n3pc parameter without cookies" in {
+      val sink = smartMock[AbstractSink]
+      sink.storeRawEvents(any[List[Array[Byte]]], anyString).answers{(params, mock) => params match {
+          case Array(firstArg, secondArg) => firstArg.asInstanceOf[List[Array[Byte]]]
+        }
+      }
+      val sinks = CollectorSinks(sink, sink)
+      val responseHandler = new ResponseHandler(collectorConfig, sinks)
+      val collectorService = new CollectorService(collectorConfig, responseHandler, system)
+      CollectorGet(s"/i?${collectorConfig.thirdPartyCookiesParameter}") ~> collectorService.collectorRoute ~> check {
+        response.status.mustEqual(StatusCodes.OK)
+        val httpCookies: List[HttpCookie] = headers.collect {
+          case `Set-Cookie`(hc) => hc
+        }
+        there was two(sink).storeRawEvents(any, any)
+        httpCookies must not be empty
+        val httpCookie = httpCookies.head
+        httpCookie.content mustEqual collectorConfig.fallbackNetworkUserId
+      }
+    }
+
+    "return the correct cookie even after calling it with n3pc parameter" in {
+      val sink = smartMock[AbstractSink]
+      sink.storeRawEvents(any[List[Array[Byte]]], anyString).answers{(params, mock) => params match {
+          case Array(firstArg, secondArg) => firstArg.asInstanceOf[List[Array[Byte]]]
+        }
+      }
+      val sinks = CollectorSinks(sink, sink)
+      val responseHandler = new ResponseHandler(collectorConfig, sinks)
+      val collectorService = new CollectorService(collectorConfig, responseHandler, system)
+
+      CollectorGet(s"/i?${collectorConfig.thirdPartyCookiesParameter}", Some(HttpCookie(collectorConfig.cookieName.get, "UUID_Test"))) ~>
+        collectorService.collectorRoute ~> check {
+        val httpCookies: List[HttpCookie] = headers.collect {
+          case `Set-Cookie`(hc) => hc
+        }
+        there was two(sink).storeRawEvents(any, any)
+        val httpCookie = httpCookies.head
+        httpCookie.content must beEqualTo("UUID_Test")
+      }
+    }
+
+    "return an invisible pixel" in {
+      val sink = new TestSink
+      val sinks = CollectorSinks(sink, sink)
+      val responseHandler = new ResponseHandler(collectorConfig, sinks)
+      val collectorService = new CollectorService(collectorConfig, responseHandler, system)
+      CollectorGet(s"/i?${collectorConfig.thirdPartyCookiesParameter}") ~> collectorService.collectorRoute ~> check {
+        responseAs[Array[Byte]] === ResponseHandler.pixel
+      }
+    }
+
+    "return a cookie expiring at the correct time" in {
+      val sink = new TestSink
+      val sinks = CollectorSinks(sink, sink)
+      val responseHandler = new ResponseHandler(collectorConfig, sinks)
+      val collectorService = new CollectorService(collectorConfig, responseHandler, system)
+      CollectorGet("/i") ~> collectorService.collectorRoute ~> check {
+        headers must not be empty
+
+        val httpCookies: List[HttpCookie] = headers.collect {
+          case `Set-Cookie`(hc) => hc
+        }
+        httpCookies must not be empty
+
+        // Assume we only return a single cookie.
+        // If the collector is modified to return multiple cookies,
+        // this will need to be changed.
+        val httpCookie = httpCookies(0)
+
+        httpCookie.name must beEqualTo(collectorConfig.cookieName.get)
+        httpCookie.domain must beSome
+        httpCookie.domain.get must be(collectorConfig.cookieDomain.get)
+        httpCookie.expires must beSome
+        val expiration = httpCookie.expires.get
+        val offset = expiration.clicks - collectorConfig.cookieExpiration.get -
+          DateTime.now.clicks
+        offset.asInstanceOf[Int] must beCloseTo(0, 3600000) // 1 hour window.
+      }
+    }
+    "return the same cookie as passed in" in {
+      val sink = new TestSink
+      val sinks = CollectorSinks(sink, sink)
+      val responseHandler = new ResponseHandler(collectorConfig, sinks)
+      val collectorService = new CollectorService(collectorConfig, responseHandler, system)
+      CollectorGet("/i", Some(HttpCookie(collectorConfig.cookieName.get, "UUID_Test"))) ~>
+          collectorService.collectorRoute ~> check {
+        val httpCookies: List[HttpCookie] = headers.collect {
+          case `Set-Cookie`(hc) => hc
+        }
+        // Assume we only return a single cookie.
+        // If the collector is modified to return multiple cookies,
+        // this will need to be changed.
+        val httpCookie = httpCookies(0)
+
+        httpCookie.content must beEqualTo("UUID_Test")
+      }
+    }
+    "return a P3P header" in {
+      val sink = new TestSink
+      val sinks = CollectorSinks(sink, sink)
+      val responseHandler = new ResponseHandler(collectorConfig, sinks)
+      val collectorService = new CollectorService(collectorConfig, responseHandler, system)
+      CollectorGet("/i") ~> collectorService.collectorRoute ~> check {
+        val p3pHeaders = headers.filter {
+          h => h.name.equals("P3P")
+        }
+        p3pHeaders.size must beEqualTo(1)
+        val p3pHeader = p3pHeaders(0)
+
+        val policyRef = collectorConfig.p3pPolicyRef
+        val CP = collectorConfig.p3pCP
+        p3pHeader.value must beEqualTo(
+          "policyref=\"%s\", CP=\"%s\"".format(policyRef, CP))
+      }
+    }
+
+    "do not store the expected event if there's no cookie" in {
+      val sink = new TestSink
+      val sinks = CollectorSinks(sink, sink)
+      val responseHandler = new ResponseHandler(collectorConfig, sinks)
+
+      val payloadData = "param1=val1&param2=val2"
+      val storedRecordBytes = responseHandler.cookie(payloadData, null, None,
+        None, "localhost", RemoteAddress("127.0.0.1"), new HttpRequest(), None, "/i", pixelExpected = true)._2
+      storedRecordBytes must beEmpty
+    }
+
+    "store the expected event as a serialized Thrift object in the enabled sink only if cookie is present" in {
+      val payloadData = "param1=val1&param2=val2"
+      val sink = new TestSink
+      val sinks = CollectorSinks(sink, sink)
+      val responseHandler = new ResponseHandler(collectorConfig, sinks)
+      val thriftDeserializer = new TDeserializer
+      val cookie = HttpCookie("SomeName",  "SOME_UUID")
+      val storedRecordBytes = responseHandler.cookie(payloadData, null, Some(cookie),
+        None, "localhost", RemoteAddress("127.0.0.1"), new HttpRequest(), None, s"/i", pixelExpected = true)._2
+
+      val storedEvent = new CollectorPayload
+      this.synchronized {
+        thriftDeserializer.deserialize(storedEvent, storedRecordBytes.head)
+      }
+
+      storedEvent.timestamp must beCloseTo(DateTime.now.clicks, 60000)
+      storedEvent.encoding must beEqualTo("UTF-8")
+      storedEvent.ipAddress must beEqualTo("127.0.0.1")
+      storedEvent.collector must beEqualTo("ssc-0.7.0-test")
+      storedEvent.path must beEqualTo("/i")
+      storedEvent.querystring must beEqualTo(payloadData)
+    }
+
+    "report itself as healthy" in {
+      val sink = smartMock[AbstractSink]
+      val sinks = CollectorSinks(sink, sink)
+      val responseHandler = new ResponseHandler(collectorConfig, sinks)
+      val collectorService = new CollectorService(collectorConfig, responseHandler, system)
+      CollectorGet("/health") ~> collectorService.collectorRoute ~> check {
+        response.status must beEqualTo(spray.http.StatusCodes.OK)
+      }
+    }
   }
 
-  "Snowplow's Scala collector" should {
+  "Snowplow's Scala collector with n3pc redirect disabled" should {
+    val collectorConfig = new CollectorConfig(testConf(n3pcEnabled = false))
+
+    // By default, spray will always add Remote-Address to every request
+    // when running with the `spray.can.server.remote-address-header`
+    // option. However, the testing does not read this option and a
+    // remote address always needs to be set.
+    def CollectorGet(uri: String, cookie: Option[`HttpCookie`] = None,
+                     remoteAddr: String = "127.0.0.1") = {
+      val headers: MutableList[HttpHeader] =
+        MutableList(`Remote-Address`(remoteAddr),`Raw-Request-URI`(uri))
+      cookie.foreach(headers += `Cookie`(_))
+      Get(uri).withHeaders(headers.toList)
+    }
+    val sink = new TestSink
+    val sinks = CollectorSinks(sink, sink)
+    val responseHandler = new ResponseHandler(collectorConfig, sinks)
+    val collectorService = new CollectorService(collectorConfig, responseHandler, system)
+    val thriftDeserializer = new TDeserializer
     "return an invisible pixel" in {
       CollectorGet("/i") ~> collectorService.collectorRoute ~> check {
+        response.status.mustEqual(StatusCodes.OK)
         responseAs[Array[Byte]] === ResponseHandler.pixel
       }
     }
@@ -145,7 +415,7 @@ collector {
     }
     "return the same cookie as passed in" in {
       CollectorGet("/i", Some(HttpCookie(collectorConfig.cookieName.get, "UUID_Test"))) ~>
-          collectorService.collectorRoute ~> check {
+        collectorService.collectorRoute ~> check {
         val httpCookies: List[HttpCookie] = headers.collect {
           case `Set-Cookie`(hc) => hc
         }
@@ -187,11 +457,6 @@ collector {
       storedEvent.collector must beEqualTo("ssc-0.7.0-test")
       storedEvent.path must beEqualTo("/i")
       storedEvent.querystring must beEqualTo(payloadData)
-    }
-    "report itself as healthy" in {
-      CollectorGet("/health") ~> collectorService.collectorRoute ~> check {
-        response.status must beEqualTo(spray.http.StatusCodes.OK)
-      }
     }
   }
 }


### PR DESCRIPTION
This is a PR provided by LiveIntent Inc, author is @jankoulaga

We implemented this feature in the least intrusive way. It can be enabled in the config. It is disabled by default. The name of the query param and the fallback UUID can be specified in the config as well.

We provided tests to make sure the current behavior did not change, even though we did a little bit of refactoring. To make the test suite run, we introduced a new dependency to a mocking framework.

Hope you like the functionality. Love to see it be released soon.

FIXES: #2697 
