### PR TITLE
Call Config.resolve() so environment variables get resolved in hocon

### DIFF
--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ScalaCollectorApp.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ScalaCollectorApp.scala
@@ -68,7 +68,7 @@ object ScalaCollector extends App {
     "Configuration file.") { (c, opt) =>
     val file = new File(c)
     if (file.exists) {
-      ConfigFactory.parseFile(file)
+      ConfigFactory.parseFile(file).resolve()
     } else {
       parser.usage("Configuration file \"%s\" does not exist".format(c))
       ConfigFactory.empty()

--- a/3-enrich/stream-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/kinesis/KinesisEnrichApp.scala
+++ b/3-enrich/stream-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/kinesis/KinesisEnrichApp.scala
@@ -93,7 +93,7 @@ object KinesisEnrichApp extends App {
     (c, opt) =>
       val file = new File(c)
       if (file.exists) {
-        ConfigFactory.parseFile(file)
+        ConfigFactory.parseFile(file).resolve()
       } else {
         parser.usage("Configuration file \"%s\" does not exist".format(c))
         ConfigFactory.empty()

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchSinkApp.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchSinkApp.scala
@@ -82,7 +82,7 @@ object ElasticsearchSinkApp extends App {
     (c, opt) =>
       val file = new File(c)
       if (file.exists) {
-        ConfigFactory.parseFile(file)
+        ConfigFactory.parseFile(file).resolve()
       } else {
         parser.usage("Configuration file \"%s\" does not exist".format(c))
         ConfigFactory.empty()


### PR DESCRIPTION
Allows passing of environment variables so config files can do substitutions

e.g. config file: `cookie { name = "${COOKIE_NAME}"  }`

lets you do: `COOKIE_NAME="example.com" ./snowplow-stream-collector-0.7.0 --config myconfig.conf`