### PR TITLE
Release/r83

### DIFF
--- a/4-storage/kinesis-elasticsearch-sink/examples/config.hocon.sample
+++ b/4-storage/kinesis-elasticsearch-sink/examples/config.hocon.sample
@@ -88,6 +88,7 @@ sink {
     max-timeout: "{{sinkElasticsearchMaxTimeout}}"
     index: "{{sinkElasticsearchIndex}}" # Elasticsearch index name
     type: "{{sinkElasticsearchType}}" # Elasticsearch type name
+    transport-port: {{sinkElasticsearchTransportPort}} # Elasticsearch transport port
   }
 
   # Events are accumulated in a buffer before being sent to Elasticsearch.

--- a/4-storage/kinesis-elasticsearch-sink/examples/config.hocon.sample
+++ b/4-storage/kinesis-elasticsearch-sink/examples/config.hocon.sample
@@ -83,12 +83,26 @@ sink {
   }
 
   elasticsearch {
-    cluster-name: "{{sinkElasticsearchClusterName}}"
-    endpoint: "{{sinkElasticsearchEndpoint}}"
-    max-timeout: "{{sinkElasticsearchMaxTimeout}}"
-    index: "{{sinkElasticsearchIndex}}" # Elasticsearch index name
-    type: "{{sinkElasticsearchType}}" # Elasticsearch type name
-    transport-port: {{sinkElasticsearchTransportPort}} # Elasticsearch transport port
+
+    # Events are indexed using an Elasticsearch Client
+    # - type: http or transport (will default to transport)
+    # - endpoint: the cluster endpoint
+    # - port: the port the cluster can be accessed on
+    #   - for http this is usually 9200
+    #   - for transport this is usually 9300
+    # - max-timeout: the maximum attempt time before a client restart
+    client {
+      type: "{{sinkElasticseachClient}}"
+      endpoint: "{{sinkElasticsearchEndpoint}}"
+      port: {{sinkElasticsearchTransportPort}}
+      max-timeout: "{{sinkElasticsearchMaxTimeout}}"
+    }
+
+    cluster {
+      name: "{{sinkElasticsearchClusterName}}"
+      index: "{{sinkElasticsearchIndex}}"
+      type: "{{sinkElasticsearchType}}"
+    }
   }
 
   # Events are accumulated in a buffer before being sent to Elasticsearch.

--- a/4-storage/kinesis-elasticsearch-sink/project/BuildSettings.scala
+++ b/4-storage/kinesis-elasticsearch-sink/project/BuildSettings.scala
@@ -20,7 +20,7 @@ object BuildSettings {
   // Basic settings for our app
   lazy val basicSettings = Seq[Setting[_]](
     organization          :=  "com.snowplowanalytics",
-    version               :=  "0.7.0",
+    version               :=  "0.7.0-rc1",
     description           :=  "Kinesis sink for Elasticsearch",
     scalaVersion          :=  "2.10.1",
     scalacOptions         :=  Seq("-deprecation", "-encoding", "utf8",

--- a/4-storage/kinesis-elasticsearch-sink/project/BuildSettings.scala
+++ b/4-storage/kinesis-elasticsearch-sink/project/BuildSettings.scala
@@ -20,7 +20,7 @@ object BuildSettings {
   // Basic settings for our app
   lazy val basicSettings = Seq[Setting[_]](
     organization          :=  "com.snowplowanalytics",
-    version               :=  "0.6.0",
+    version               :=  "0.7.0",
     description           :=  "Kinesis sink for Elasticsearch",
     scalaVersion          :=  "2.10.1",
     scalacOptions         :=  Seq("-deprecation", "-encoding", "utf8",

--- a/4-storage/kinesis-elasticsearch-sink/project/BuildSettings.scala
+++ b/4-storage/kinesis-elasticsearch-sink/project/BuildSettings.scala
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2014-2016 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,

--- a/4-storage/kinesis-elasticsearch-sink/project/Dependencies.scala
+++ b/4-storage/kinesis-elasticsearch-sink/project/Dependencies.scala
@@ -1,5 +1,5 @@
-/*
- * Copyright (c) 2014 Snowplow Analytics Ltd. All rights reserved.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -10,6 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
+
 import sbt._
 
 object Dependencies {

--- a/4-storage/kinesis-elasticsearch-sink/project/Dependencies.scala
+++ b/4-storage/kinesis-elasticsearch-sink/project/Dependencies.scala
@@ -53,6 +53,7 @@ object Dependencies {
     // Java
     val logging              = "commons-logging"            %  "commons-logging"           % V.logging
     val slf4j                = "org.slf4j"                  %  "slf4j-simple"              % V.slf4j
+    val log4jOverSlf4j       = "org.slf4j"                  %  "log4j-over-slf4j"          % V.slf4j
     val kinesisClient        = "com.amazonaws"              %  "amazon-kinesis-client"     % V.kinesisClient
     val kinesisConnector     = "com.amazonaws"              %  "amazon-kinesis-connectors" % V.kinesisConnector
     val elasticsearch        = "org.elasticsearch"          %  "elasticsearch"             % V.elasticsearch

--- a/4-storage/kinesis-elasticsearch-sink/project/Dependencies.scala
+++ b/4-storage/kinesis-elasticsearch-sink/project/Dependencies.scala
@@ -32,6 +32,7 @@ object Dependencies {
     val kinesisClient        = "1.6.1"
     val kinesisConnector     = "1.1.2"
     val elasticsearch        = "1.4.4"
+    val jest                 = "1.0.3"
     // Scala
     val argot                = "1.0.1"
     val config               = "1.0.2"
@@ -55,6 +56,7 @@ object Dependencies {
     val kinesisClient        = "com.amazonaws"              %  "amazon-kinesis-client"     % V.kinesisClient
     val kinesisConnector     = "com.amazonaws"              %  "amazon-kinesis-connectors" % V.kinesisConnector
     val elasticsearch        = "org.elasticsearch"          %  "elasticsearch"             % V.elasticsearch
+    val jest                 = "io.searchbox"               %  "jest"                      % V.jest
     // Scala
     val argot                = "org.clapper"                %% "argot"                     % V.argot
     val config               = "com.typesafe"               %  "config"                    % V.config

--- a/4-storage/kinesis-elasticsearch-sink/project/SnowplowElasticsearchSinkBuild.scala
+++ b/4-storage/kinesis-elasticsearch-sink/project/SnowplowElasticsearchSinkBuild.scala
@@ -44,7 +44,8 @@ object SnowplowElasticsearchSinkBuild extends Build {
         Libraries.kinesisClient,
         Libraries.kinesisConnector,
         Libraries.snowplowTracker,
-        Libraries.elasticsearch
+        Libraries.elasticsearch,
+        Libraries.jest
       )
     )
 }

--- a/4-storage/kinesis-elasticsearch-sink/project/SnowplowElasticsearchSinkBuild.scala
+++ b/4-storage/kinesis-elasticsearch-sink/project/SnowplowElasticsearchSinkBuild.scala
@@ -1,5 +1,5 @@
-/* 
- * Copyright (c) 2014 Snowplow Analytics Ltd. All rights reserved.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -10,6 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
+
 import sbt._
 import Keys._
 

--- a/4-storage/kinesis-elasticsearch-sink/project/SnowplowElasticsearchSinkBuild.scala
+++ b/4-storage/kinesis-elasticsearch-sink/project/SnowplowElasticsearchSinkBuild.scala
@@ -41,6 +41,7 @@ object SnowplowElasticsearchSinkBuild extends Build {
         Libraries.scalazSpecs2,
         Libraries.commonsLang3,
         Libraries.slf4j,
+        Libraries.log4jOverSlf4j,
         Libraries.kinesisClient,
         Libraries.kinesisConnector,
         Libraries.snowplowTracker,

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/BadEventTransformer.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/BadEventTransformer.scala
@@ -1,5 +1,5 @@
- /*
- * Copyright (c) 2014 Snowplow Analytics Ltd.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd.
  * All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
@@ -16,6 +16,7 @@
  * See the Apache License Version 2.0 for the specific language
  * governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch
 
 // Java

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/CredentialsLookup.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/CredentialsLookup.scala
@@ -1,5 +1,5 @@
- /*
- * Copyright (c) 2014 Snowplow Analytics Ltd.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd.
  * All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
@@ -16,6 +16,7 @@
  * See the Apache License Version 2.0 for the specific language
  * governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch
 
 // Amazon

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchPipeline.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchPipeline.scala
@@ -1,5 +1,5 @@
- /*
- * Copyright (c) 2014 Snowplow Analytics Ltd.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd.
  * All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
@@ -16,6 +16,7 @@
  * See the Apache License Version 2.0 for the specific language
  * governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow
 package storage.kinesis.elasticsearch
 

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchPipeline.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchPipeline.scala
@@ -54,6 +54,7 @@ import scalatracker.Tracker
  * @param tracker a Tracker instance
  * @param maxConnectionTime the maximum amount of time
  *        we can attempt to send to elasticsearch
+ * @param elasticsearchClientType The type of ES Client to use
  */
 class ElasticsearchPipeline(
   streamType: StreamType,
@@ -62,10 +63,12 @@ class ElasticsearchPipeline(
   goodSink: Option[ISink],
   badSink: ISink,
   tracker: Option[Tracker] = None,
-  maxConnectionTime: Long) extends IKinesisConnectorPipeline[ValidatedRecord, EmitterInput] {
+  maxConnectionTime: Long,
+  elasticsearchClientType: String
+) extends IKinesisConnectorPipeline[ValidatedRecord, EmitterInput] {
 
   override def getEmitter(configuration: KinesisConnectorConfiguration): IEmitter[EmitterInput] =
-    new SnowplowElasticsearchEmitter(configuration, goodSink, badSink, tracker, maxConnectionTime)
+    new SnowplowElasticsearchEmitter(configuration, goodSink, badSink, tracker, maxConnectionTime, elasticsearchClientType)
 
   override def getBuffer(configuration: KinesisConnectorConfiguration) = new BasicMemoryBuffer[ValidatedRecord](configuration)
 

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchSinkApp.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchSinkApp.scala
@@ -1,4 +1,4 @@
- /*
+/**
  * Copyright (c) 2014-2016 Snowplow Analytics Ltd.
  * All rights reserved.
  *
@@ -16,6 +16,7 @@
  * See the Apache License Version 2.0 for the specific language
  * governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch
 
 // Java
@@ -155,6 +156,7 @@ object ElasticsearchSinkApp extends App {
         )
       }
     }.success
+
     case _ => "Source must be set to 'stdin' or 'kinesis'".fail
   }
 

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchSinkApp.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchSinkApp.scala
@@ -54,13 +54,13 @@ import com.snowplowanalytics.snowplow.enrich.common.outputs.BadRow
 
 // This project
 import sinks._
+import clients._
 
 // Whether the input stream contains enriched events or bad events
 object StreamType extends Enumeration {
   type StreamType = Value
   val Good, Bad = Value
 }
-
 
 /**
  * Main entry point for the Elasticsearch sink
@@ -100,9 +100,13 @@ object ElasticsearchSinkApp extends App {
     case "bad" => StreamType.Bad
     case _ => throw new RuntimeException("\"stream-type\" must be set to \"good\" or \"bad\"")
   }
+
   val elasticsearch = configValue.getConfig("elasticsearch")
-  val documentIndex = elasticsearch.getString("index")
-  val documentType = elasticsearch.getString("type")
+  val esClient = elasticsearch.getConfig("client")
+  val esCluster = elasticsearch.getConfig("cluster")
+  val clientType = esClient.getString("type")
+  val documentIndex = esCluster.getString("index")
+  val documentType = esCluster.getString("type")
 
   val tracker = if (configValue.hasPath("monitoring.snowplow")) {
     SnowplowTracking.initializeTracker(configValue.getConfig("monitoring.snowplow")).some
@@ -110,12 +114,14 @@ object ElasticsearchSinkApp extends App {
     None
   }
 
-  val maxConnectionTime = configValue.getConfig("elasticsearch").getLong("max-timeout")
+  val maxConnectionTime = configValue.getConfig("elasticsearch.client").getLong("max-timeout")
   val finalConfig = convertConfig(configValue)
+
   val goodSink = configValue.getString("sink.good") match {
     case "stdout" => Some(new StdouterrSink)
     case "elasticsearch" => None
   }
+
   val badSink = configValue.getString("sink.bad") match {
     case "stderr" => new StdouterrSink
     case "none" => new NullSink
@@ -134,7 +140,7 @@ object ElasticsearchSinkApp extends App {
 
     // Read records from Kinesis
     case "kinesis" => {
-      new ElasticsearchSinkExecutor(streamType, documentIndex, documentType, finalConfig, goodSink, badSink, tracker, maxConnectionTime).success
+      new ElasticsearchSinkExecutor(streamType, documentIndex, documentType, finalConfig, goodSink, badSink, tracker, maxConnectionTime, clientType).success
     }
 
     // Run locally, reading from stdin and sending events to stdout / stderr rather than Elasticsearch / Kinesis
@@ -144,7 +150,15 @@ object ElasticsearchSinkApp extends App {
         case StreamType.Good => new SnowplowElasticsearchTransformer(documentIndex, documentType)
         case StreamType.Bad => new BadEventTransformer(documentIndex, documentType)
       }
-      lazy val elasticsearchSender = new ElasticsearchSender(finalConfig, None, maxConnectionTime)
+
+      lazy val elasticsearchSender: ElasticsearchSender = (
+        if (clientType == "http") {
+          new ElasticsearchSenderHTTP(finalConfig, None, maxConnectionTime)
+        } else {
+          new ElasticsearchSenderTransport(finalConfig, None, maxConnectionTime)
+        }
+      )
+
       def run = for (ln <- scala.io.Source.stdin.getLines) {
         val emitterInput = transformer.consumeLine(ln)
         emitterInput._2.bimap(
@@ -187,9 +201,11 @@ object ElasticsearchSinkApp extends App {
     val secretKey = aws.getString("secret-key")
 
     val elasticsearch = connector.getConfig("elasticsearch")
-    val elasticsearchEndpoint = elasticsearch.getString("endpoint")
-    val elasticsearchTransportPort = elasticsearch.getString("transport-port")
-    val clusterName = elasticsearch.getString("cluster-name")
+    val esClient = elasticsearch.getConfig("client")
+    val esCluster = elasticsearch.getConfig("cluster")
+    val elasticsearchEndpoint = esClient.getString("endpoint")
+    val elasticsearchPort = esClient.getString("port")
+    val clusterName = esCluster.getString("name")
 
     val kinesis = connector.getConfig("kinesis")
     val kinesisIn = kinesis.getConfig("in")
@@ -222,7 +238,7 @@ object ElasticsearchSinkApp extends App {
 
     props.setProperty(KinesisConnectorConfiguration.PROP_ELASTICSEARCH_ENDPOINT, elasticsearchEndpoint)
     props.setProperty(KinesisConnectorConfiguration.PROP_ELASTICSEARCH_CLUSTER_NAME, clusterName)
-    props.setProperty(KinesisConnectorConfiguration.PROP_ELASTICSEARCH_PORT, elasticsearchTransportPort)
+    props.setProperty(KinesisConnectorConfiguration.PROP_ELASTICSEARCH_PORT, elasticsearchPort)
 
     props.setProperty(KinesisConnectorConfiguration.PROP_BUFFER_BYTE_SIZE_LIMIT, byteLimit)
     props.setProperty(KinesisConnectorConfiguration.PROP_BUFFER_RECORD_COUNT_LIMIT, recordLimit)
@@ -233,5 +249,4 @@ object ElasticsearchSinkApp extends App {
 
     new KinesisConnectorConfiguration(props, CredentialsLookup.getCredentialsProvider(accessKey, secretKey))
   }
-
 }

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchSinkApp.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchSinkApp.scala
@@ -188,6 +188,7 @@ object ElasticsearchSinkApp extends App {
 
     val elasticsearch = connector.getConfig("elasticsearch")
     val elasticsearchEndpoint = elasticsearch.getString("endpoint")
+    val elasticsearchTransportPort = elasticsearch.getString("transport-port")
     val clusterName = elasticsearch.getString("cluster-name")
 
     val kinesis = connector.getConfig("kinesis")
@@ -221,6 +222,7 @@ object ElasticsearchSinkApp extends App {
 
     props.setProperty(KinesisConnectorConfiguration.PROP_ELASTICSEARCH_ENDPOINT, elasticsearchEndpoint)
     props.setProperty(KinesisConnectorConfiguration.PROP_ELASTICSEARCH_CLUSTER_NAME, clusterName)
+    props.setProperty(KinesisConnectorConfiguration.PROP_ELASTICSEARCH_PORT, elasticsearchTransportPort)
 
     props.setProperty(KinesisConnectorConfiguration.PROP_BUFFER_BYTE_SIZE_LIMIT, byteLimit)
     props.setProperty(KinesisConnectorConfiguration.PROP_BUFFER_RECORD_COUNT_LIMIT, recordLimit)

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchSinkExecutor.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchSinkExecutor.scala
@@ -1,5 +1,5 @@
- /*
- * Copyright (c) 2014 Snowplow Analytics Ltd.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd.
  * All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
@@ -16,6 +16,7 @@
  * See the Apache License Version 2.0 for the specific language
  * governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow
 package storage.kinesis.elasticsearch
 

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchSinkExecutor.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchSinkExecutor.scala
@@ -47,6 +47,7 @@ import StreamType._
  * @param tracker a Tracker instance
  * @param maxConnectionTimeout the maximum amount of time
  *        we can attempt to send to elasticsearch
+ * @param elasticsearchClientType The type of ES Client to use
  */
 class ElasticsearchSinkExecutor(
   streamType: StreamType,
@@ -56,11 +57,13 @@ class ElasticsearchSinkExecutor(
   goodSink: Option[ISink],
   badSink: ISink,
   tracker: Option[Tracker] = None,
-  maxConnectionTimeout: Long = 60000) extends KinesisConnectorExecutorBase[ValidatedRecord, EmitterInput] {
+  maxConnectionTimeout: Long = 60000,
+  elasticsearchClientType: String
+) extends KinesisConnectorExecutorBase[ValidatedRecord, EmitterInput] {
 
   initialize(config)
   override def getKinesisConnectorRecordProcessorFactory = {
     new KinesisConnectorRecordProcessorFactory[ValidatedRecord, EmitterInput](
-      new ElasticsearchPipeline(streamType, documentIndex, documentType, goodSink, badSink, tracker, maxConnectionTimeout), config)
+      new ElasticsearchPipeline(streamType, documentIndex, documentType, goodSink, badSink, tracker, maxConnectionTimeout, elasticsearchClientType), config)
   }
 }

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/FailureUtils.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/FailureUtils.scala
@@ -1,5 +1,5 @@
- /*
- * Copyright (c) 2014 Snowplow Analytics Ltd.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd.
  * All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
@@ -16,6 +16,7 @@
  * See the Apache License Version 2.0 for the specific language
  * governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch
 
 // Scalaz

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/JsonRecord.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/JsonRecord.scala
@@ -1,5 +1,5 @@
- /*
- * Copyright (c) 2014 Snowplow Analytics Ltd.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd.
  * All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
@@ -16,6 +16,7 @@
  * See the Apache License Version 2.0 for the specific language
  * governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch
 
 /**

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/Shredder.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/Shredder.scala
@@ -1,5 +1,5 @@
- /*
- * Copyright (c) 2014 Snowplow Analytics Ltd.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd.
  * All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
@@ -16,6 +16,7 @@
  * See the Apache License Version 2.0 for the specific language
  * governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch
 
 // Scalaz

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/SnowplowElasticsearchEmitter.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/SnowplowElasticsearchEmitter.scala
@@ -1,21 +1,21 @@
- /*
-  * Copyright (c) 2014 Snowplow Analytics Ltd.
-  * All rights reserved.
-  *
-  * This program is licensed to you under the Apache License Version 2.0,
-  * and you may not use this file except in compliance with the Apache
-  * License Version 2.0.
-  * You may obtain a copy of the Apache License Version 2.0 at
-  * http://www.apache.org/licenses/LICENSE-2.0.
-  *
-  * Unless required by applicable law or agreed to in writing,
-  * software distributed under the Apache License Version 2.0 is distributed
-  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-  * either express or implied.
-  *
-  * See the Apache License Version 2.0 for the specific language
-  * governing permissions and limitations there under.
-  */
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache
+ * License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.
+ *
+ * See the Apache License Version 2.0 for the specific language
+ * governing permissions and limitations there under.
+ */
 
 package com.snowplowanalytics.snowplow
 package storage.kinesis.elasticsearch

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/SnowplowElasticsearchTransformer.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/SnowplowElasticsearchTransformer.scala
@@ -1,5 +1,5 @@
- /*
- * Copyright (c) 2014 Snowplow Analytics Ltd.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd.
  * All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
@@ -16,6 +16,7 @@
  * See the Apache License Version 2.0 for the specific language
  * governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow
 package storage.kinesis.elasticsearch
 

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/SnowplowTracking.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/SnowplowTracking.scala
@@ -1,5 +1,5 @@
- /*
- * Copyright (c) 2014 Snowplow Analytics Ltd.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd.
  * All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
@@ -16,6 +16,7 @@
  * See the Apache License Version 2.0 for the specific language
  * governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch
 
 // json4s

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/StdinTransformer.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/StdinTransformer.scala
@@ -1,5 +1,5 @@
- /*
- * Copyright (c) 2014 Snowplow Analytics Ltd.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd.
  * All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
@@ -16,6 +16,7 @@
  * See the Apache License Version 2.0 for the specific language
  * governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch
 
 /**

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/clients/ElasticsearchSender.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/clients/ElasticsearchSender.scala
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2016 Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache
+ * License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.
+ *
+ * See the Apache License Version 2.0 for the specific language
+ * governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch
+package clients
+
+/**
+ * Abstract class for Elasticsearch clients
+ */
+abstract class ElasticsearchSender extends IElasticsearchSender {
+
+  /**
+   * Period between retrying sending events to Elasticsearch
+   *
+   * @param sleepTime Length of time between tries
+   */
+  protected def sleep(sleepTime: Long): Unit = {
+    try {
+      Thread.sleep(sleepTime)
+    } catch {
+      case e: InterruptedException => ()
+    }
+  }
+}

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/clients/ElasticsearchSenderHTTP.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/clients/ElasticsearchSenderHTTP.scala
@@ -1,0 +1,234 @@
+/**
+ * Copyright (c) 2016 Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache
+ * License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.
+ *
+ * See the Apache License Version 2.0 for the specific language
+ * governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch
+package clients
+
+// Amazon
+import com.amazonaws.services.kinesis.connectors.KinesisConnectorConfiguration
+
+// Jest
+import io.searchbox.client.{
+  JestClient,
+  JestClientFactory
+}
+import io.searchbox.core._
+import io.searchbox.client.config.HttpClientConfig
+import io.searchbox.cluster.Health
+
+// Java
+import java.util.concurrent.TimeUnit;
+
+// Joda-Time
+import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.format.DateTimeFormat
+
+// Scala
+import scala.collection.JavaConversions._
+import scala.annotation.tailrec
+
+// Scalaz
+import scalaz._
+import Scalaz._
+
+// json4s
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+import org.json4s.JsonDSL._
+
+// Logging
+import org.apache.commons.logging.{
+  Log,
+  LogFactory
+}
+
+// Tracker
+import com.snowplowanalytics.snowplow.scalatracker.Tracker
+
+// This project
+import sinks._
+
+/**
+ * Sends Elasticsearch documents via the HTTP Jest Client.
+ * Batches are bulk sent to the end point.
+ */
+class ElasticsearchSenderHTTP(
+  configuration: KinesisConnectorConfiguration,
+  tracker: Option[Tracker] = None,
+  maxConnectionWaitTimeMs: Long = 60000
+) extends ElasticsearchSender {
+
+  private val Log = LogFactory.getLog(getClass)
+
+  // An ISO valid timestamp formatter
+  private val TstampFormat = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(DateTimeZone.UTC)
+
+  /**
+   * Prepare the elasticsearch client
+   */
+  private val factory: JestClientFactory = new JestClientFactory()
+  factory.setHttpClientConfig(new HttpClientConfig
+    .Builder("http://" + configuration.ELASTICSEARCH_ENDPOINT + ":" + configuration.ELASTICSEARCH_PORT)
+    .multiThreaded(true)
+    .discoveryEnabled(false)
+    .maxConnectionIdleTime(30L, TimeUnit.SECONDS)
+    .connTimeout(5000)
+    .readTimeout(5000)
+    .build()
+  )
+  private val elasticsearchClient: JestClient = factory.getObject()
+
+  /**
+   * The Elasticsearch endpoint.
+   */
+  private val elasticsearchEndpoint = configuration.ELASTICSEARCH_ENDPOINT
+
+  /**
+   * The Elasticsearch port.
+   */
+  private val elasticsearchPort = configuration.ELASTICSEARCH_PORT
+
+  /**
+   * The amount of time to wait in between unsuccessful index requests (in milliseconds).
+   * 10 seconds = 10 * 1000 = 10000
+   */
+  private val BackoffPeriod = 10000
+       
+  Log.info("ElasticsearchSender using elasticsearch endpoint " + elasticsearchEndpoint + ":" + elasticsearchPort)
+
+  /**
+   * Emits good records to Elasticsearch and bad records to Kinesis.
+   * All valid records in the buffer get sent to Elasticsearch in a bulk request.
+   * All invalid requests and all requests which failed transformation get sent to Kinesis.
+   *
+   * @param records List of records to send to Elasticsearch
+   * @return List of inputs which Elasticsearch rejected
+   */
+  def sendToElasticsearch(records: List[EmitterInput]): List[EmitterInput] = {
+
+    val actions: List[io.searchbox.core.Index] = for {
+      (_, Success(record)) <- records
+    } yield {
+      new io.searchbox.core.Index.Builder(record.getSource)
+        .index(record.getIndex)
+        .`type`(record.getType)
+        .id(record.getId)
+        .build()
+    }
+
+    val bulkRequest = new io.searchbox.core.Bulk.Builder()
+      .addAction(actions)
+      .build()
+
+    val connectionAttemptStartTime = System.currentTimeMillis()
+
+    /**
+     * Keep attempting to execute the buldRequest until it succeeds
+     *
+     * @return List of inputs which Elasticsearch rejected
+     */
+    @tailrec def attemptEmit(attemptNumber: Long = 1): List[EmitterInput] = {
+
+      if (attemptNumber > 1 && System.currentTimeMillis() - connectionAttemptStartTime > maxConnectionWaitTimeMs) {
+        forceShutdown()
+      }
+
+      try {
+        val bulkResponse: io.searchbox.core.BulkResult = elasticsearchClient.execute(bulkRequest)
+        val responses = bulkResponse.getItems
+
+        val allFailures = responses.toList.zip(records).filter(_._1.error != null).map(pair => {
+          val (response, record) = pair
+          val failure = response.error
+
+          Log.error("Record failed with message: " + failure)
+
+          if (failure.contains("DocumentAlreadyExistsException") || failure.contains("VersionConflictEngineException")) {
+            None
+          } else {
+            Some(record._1 -> List("Elasticsearch rejected record with message: %s".format(failure)).fail)
+          }
+        })
+
+        val numberOfSkippedRecords = allFailures.count(_.isEmpty)
+        val failures = allFailures.flatten
+
+        Log.info("Emitted " + (records.size - failures.size - numberOfSkippedRecords) + " records to Elasticsearch")
+
+        if (!failures.isEmpty) {
+          printClusterStatus
+          Log.warn("Returning " + failures.size + " records as failed")
+        }
+
+        failures
+      } catch {
+        case e: Exception => {
+          Log.error("ElasticsearchEmitter threw an unexpected exception ", e)
+          sleep(BackoffPeriod)
+          tracker foreach {
+            t => SnowplowTracking.sendFailureEvent(t, BackoffPeriod, attemptNumber, connectionAttemptStartTime, e.toString)
+          }
+          attemptEmit(attemptNumber + 1)
+        }
+      }
+    }
+
+    attemptEmit()
+  }
+
+  /**
+   * Shuts the client down
+   */
+  def close(): Unit = {
+    elasticsearchClient.shutdownClient
+  }
+
+  /**
+   * Logs the Elasticsearch cluster's health
+   */
+  private def printClusterStatus: Unit = {
+    val response = elasticsearchClient.execute(new Health.Builder().build())
+    val status = response.getValue("status").toString
+    if (status == "red") {
+      Log.error("Cluster health is RED. Indexing ability will be limited")
+    } else if (status == "yellow") {
+      Log.warn("Cluster health is YELLOW.")
+    } else if (status == "green") {
+      Log.info("Cluster health is GREEN.")
+    }
+  }
+
+  /**
+   * Terminate the application in a way the KCL cannot stop
+   *
+   * Prevents shutdown hooks from running
+   */
+  private def forceShutdown() {
+    Log.error(s"Shutting down application as unable to connect to Elasticsearch for over $maxConnectionWaitTimeMs ms")
+
+    tracker foreach {
+      t =>
+        // TODO: Instead of waiting a fixed time, use synchronous tracking or futures (when the tracker supports futures)
+        SnowplowTracking.trackApplicationShutdown(t)
+        sleep(5000)
+    }
+
+    Runtime.getRuntime.halt(1)
+  }
+}

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/clients/ElasticsearchSenderTransport.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/clients/ElasticsearchSenderTransport.scala
@@ -1,24 +1,24 @@
- /*
-  * Copyright (c) 2016 Snowplow Analytics Ltd.
-  * All rights reserved.
-  *
-  * This program is licensed to you under the Apache License Version 2.0,
-  * and you may not use this file except in compliance with the Apache
-  * License Version 2.0.
-  * You may obtain a copy of the Apache License Version 2.0 at
-  * http://www.apache.org/licenses/LICENSE-2.0.
-  *
-  * Unless required by applicable law or agreed to in writing,
-  * software distributed under the Apache License Version 2.0 is distributed
-  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-  * either express or implied.
-  *
-  * See the Apache License Version 2.0 for the specific language
-  * governing permissions and limitations there under.
-  */
-package com.snowplowanalytics.snowplow
-package storage.kinesis.elasticsearch
+/**
+ * Copyright (c) 2016 Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache
+ * License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.
+ *
+ * See the Apache License Version 2.0 for the specific language
+ * governing permissions and limitations there under.
+ */
 
+package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch
+package clients
 
 // Amazon
 import com.amazonaws.services.kinesis.connectors.KinesisConnectorConfiguration
@@ -56,10 +56,6 @@ import com.amazonaws.services.kinesis.connectors.{
   UnmodifiableBuffer
 }
 
-// Java
-import java.io.IOException
-import java.util.{List => JList}
-
 // Joda-Time
 import org.joda.time.{DateTime, DateTimeZone}
 import org.joda.time.format.DateTimeFormat
@@ -84,20 +80,17 @@ import org.apache.commons.logging.{
 }
 
 // Tracker
-import scalatracker.Tracker
-import scalatracker.SelfDescribingJson
-
-// Common Enrich
-import com.snowplowanalytics.snowplow.enrich.common.outputs.BadRow
+import com.snowplowanalytics.snowplow.scalatracker.Tracker
 
 // This project
 import sinks._
 
-class ElasticsearchSender(
+class ElasticsearchSenderTransport(
   configuration: KinesisConnectorConfiguration,
   tracker: Option[Tracker] = None,
   maxConnectionWaitTimeMs: Long = 60000
-) {
+) extends ElasticsearchSender {
+
   private val Log = LogFactory.getLog(getClass)
 
   // An ISO valid timestamp formatter
@@ -226,26 +219,27 @@ class ElasticsearchSender(
 
         val allFailures = responses.toList.zip(records).filter(_._1.isFailed).map(pair => {
           val (response, record) = pair
-          Log.error("Record failed with message: " + response.getFailureMessage)
           val failure = response.getFailure
-          if (failure.getMessage.contains("DocumentAlreadyExistsException")
-              || failure.getMessage.contains("VersionConflictEngineException")) {
+
+          Log.error("Record failed with message: " + response.getFailureMessage)
+          
+          if (failure.getMessage.contains("DocumentAlreadyExistsException") || failure.getMessage.contains("VersionConflictEngineException")) {
             None
           } else {
-            Some(record._1 -> List("Elasticsearch rejected record with message: %s"
-              .format(failure.getMessage)).fail)
+            Some(record._1 -> List("Elasticsearch rejected record with message: %s".format(failure.getMessage)).fail)
           }
         })
 
         val numberOfSkippedRecords = allFailures.count(_.isEmpty)
         val failures = allFailures.flatten
 
-        Log.info("Emitted " + (records.size - failures.size - numberOfSkippedRecords)
-          + " records to Elasticsearch")
+        Log.info("Emitted " + (records.size - failures.size - numberOfSkippedRecords) + " records to Elasticsearch")
+
         if (!failures.isEmpty) {
           printClusterStatus
           Log.warn("Returning " + failures.size + " records as failed")
         }
+
         failures
       } catch {
         case nnae: NoNodeAvailableException => {
@@ -272,6 +266,28 @@ class ElasticsearchSender(
   }
 
   /**
+   * Shuts the client down
+   */
+  def close(): Unit = {
+    elasticsearchClient.close
+  }
+
+  /**
+   * Logs the Elasticsearch cluster's health
+   */
+  private def printClusterStatus: Unit = {
+    val healthRequestBuilder = elasticsearchClient.admin.cluster.prepareHealth()
+    val response = healthRequestBuilder.execute.actionGet
+    if (response.getStatus.equals(ClusterHealthStatus.RED)) {
+      Log.error("Cluster health is RED. Indexing ability will be limited")
+    } else if (response.getStatus.equals(ClusterHealthStatus.YELLOW)) {
+      Log.warn("Cluster health is YELLOW.")
+    } else if (response.getStatus.equals(ClusterHealthStatus.GREEN)) {
+      Log.info("Cluster health is GREEN.")
+    }
+  }
+
+  /**
    * Terminate the application in a way the KCL cannot stop
    *
    * Prevents shutdown hooks from running
@@ -287,37 +303,5 @@ class ElasticsearchSender(
     }
 
     Runtime.getRuntime.halt(1)
-  }
-
-  /**
-   * Logs the Elasticsearch cluster's health
-   */
-  private def printClusterStatus {
-    val healthRequestBuilder = elasticsearchClient.admin.cluster.prepareHealth()
-    val response = healthRequestBuilder.execute.actionGet
-    if (response.getStatus.equals(ClusterHealthStatus.RED)) {
-      Log.error("Cluster health is RED. Indexing ability will be limited")
-    } else if (response.getStatus.equals(ClusterHealthStatus.YELLOW)) {
-      Log.warn("Cluster health is YELLOW.")
-    } else if (response.getStatus.equals(ClusterHealthStatus.GREEN)) {
-      Log.info("Cluster health is GREEN.")
-    }
-  }
-
-  /**
-   * Period between retrying sending events to Elasticsearch
-   *
-   * @param sleepTime Length of time between tries
-   */
-  private def sleep(sleepTime: Long): Unit = {
-    try {
-      Thread.sleep(sleepTime)
-    } catch {
-      case e: InterruptedException => ()
-    }
-  }
-
-  def close(): Unit = {
-    elasticsearchClient.close
   }
 }

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/clients/IElasticsearchSender.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/clients/IElasticsearchSender.scala
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2016 Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache
+ * License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.
+ *
+ * See the Apache License Version 2.0 for the specific language
+ * governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch
+package clients
+
+/**
+ * Common interface for Elasticsearch clients
+ */
+trait IElasticsearchSender {
+  def sendToElasticsearch(records: List[EmitterInput]): List[EmitterInput]
+  def close(): Unit
+}

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/sinks/ISink.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/sinks/ISink.scala
@@ -1,5 +1,5 @@
- /*
- * Copyright (c) 2014 Snowplow Analytics Ltd.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd.
  * All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
@@ -16,6 +16,7 @@
  * See the Apache License Version 2.0 for the specific language
  * governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch
 package sinks
 

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/sinks/KinesisSink.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/sinks/KinesisSink.scala
@@ -1,5 +1,5 @@
- /*
- * Copyright (c) 2014 Snowplow Analytics Ltd.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd.
  * All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
@@ -16,6 +16,7 @@
  * See the Apache License Version 2.0 for the specific language
  * governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch.sinks
 
 // Java

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/sinks/StdouterrSink.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/sinks/StdouterrSink.scala
@@ -1,5 +1,5 @@
- /*
- * Copyright (c) 2014 Snowplow Analytics Ltd.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd.
  * All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
@@ -16,6 +16,7 @@
  * See the Apache License Version 2.0 for the specific language
  * governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch.sinks
 
 /**

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/package.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/package.scala
@@ -1,5 +1,5 @@
- /*
- * Copyright (c) 2014 Snowplow Analytics Ltd.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd.
  * All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
@@ -16,7 +16,6 @@
  * See the Apache License Version 2.0 for the specific language
  * governing permissions and limitations there under.
  */
-// TODO make this a package object
 
 package com.snowplowanalytics.snowplow.storage.kinesis
 

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/package.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/package.scala
@@ -39,6 +39,9 @@ package object elasticsearch {
    */
   type ValidatedRecord = (String, Validation[List[String], JsonRecord])
 
+  /**
+   * The input type for the ElasticsearchSender objects
+   */
   type EmitterInput = (String, Validation[List[String], ElasticsearchObject])
 
   /**

--- a/4-storage/kinesis-elasticsearch-sink/src/test/scala/com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch/BadEventTransformerSpec.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/test/scala/com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch/BadEventTransformerSpec.scala
@@ -1,5 +1,5 @@
-/*
- * Copyright (c) 2014 Snowplow Analytics Ltd. All rights reserved.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -10,6 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow
 package storage.kinesis.elasticsearch
 

--- a/4-storage/kinesis-elasticsearch-sink/src/test/scala/com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch/ShredderSpec.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/test/scala/com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch/ShredderSpec.scala
@@ -1,5 +1,5 @@
-/*
- * Copyright (c) 2014 Snowplow Analytics Ltd. All rights reserved.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -10,6 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch
 
 // Scalaz

--- a/4-storage/kinesis-elasticsearch-sink/src/test/scala/com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch/SnowplowElasticsearchEmitterSpec.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/test/scala/com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch/SnowplowElasticsearchEmitterSpec.scala
@@ -1,5 +1,5 @@
-/*
- * Copyright (c) 2014 Snowplow Analytics Ltd. All rights reserved.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -10,6 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch
 
 // Java

--- a/4-storage/kinesis-elasticsearch-sink/src/test/scala/com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch/SnowplowElasticsearchTransformerSpec.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/test/scala/com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch/SnowplowElasticsearchTransformerSpec.scala
@@ -1,5 +1,5 @@
-/*
- * Copyright (c) 2014 Snowplow Analytics Ltd. All rights reserved.
+/**
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -10,6 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow
 package storage.kinesis.elasticsearch
 

--- a/ci.bash
+++ b/ci.bash
@@ -12,7 +12,7 @@ root=$(pwd)
 # Next two arrays MUST match up: number of elements and order
 declare -a kinesis_app_paths=( "2-collectors/scala-stream-collector" "3-enrich/stream-enrich" "4-storage/kinesis-elasticsearch-sink" )
 # TODO: version numbers shouldn't be hard-coded
-declare -a kinesis_fatjars=( "snowplow-stream-collector-0.7.0" "snowplow-stream-enrich-0.8.1" "snowplow-elasticsearch-sink-0.6.0" )
+declare -a kinesis_fatjars=( "snowplow-stream-collector-0.7.0" "snowplow-stream-enrich-0.8.1" "snowplow-elasticsearch-sink-0.7.0" )
 
 # Similar to Perl die
 function die() {

--- a/ci.bash
+++ b/ci.bash
@@ -12,7 +12,7 @@ root=$(pwd)
 # Next two arrays MUST match up: number of elements and order
 declare -a kinesis_app_paths=( "2-collectors/scala-stream-collector" "3-enrich/stream-enrich" "4-storage/kinesis-elasticsearch-sink" )
 # TODO: version numbers shouldn't be hard-coded
-declare -a kinesis_fatjars=( "snowplow-stream-collector-0.7.0" "snowplow-stream-enrich-0.8.1" "snowplow-elasticsearch-sink-0.7.0" )
+declare -a kinesis_fatjars=( "snowplow-stream-collector-0.7.0" "snowplow-stream-enrich-0.8.1" "snowplow-elasticsearch-sink-0.7.0-rc1" )
 
 # Similar to Perl die
 function die() {


### PR DESCRIPTION
@alexanderdean updates for R83:

1. Port for Kinesis Elasticsearch Sink must be configured
  - Note has been made in example hocon about generic ports to use
  - Should default ports be included?
2. Can specify to use either HTTP or Transport Clients
  - Both use the Bulk API for performance
3. Logger level can now be specified from command line