### PR TITLE
Patch for #2813

### DIFF
--- a/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/emr_job.rb
+++ b/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/emr_job.rb
@@ -707,8 +707,9 @@ module Snowplow
       # +region+:: the AWS region to source hosted assets from
       Contract String, String => String
       def self.get_hosted_assets_bucket(bucket, region)
+        bucket = bucket.chomp('/')
         suffix = if !bucket.eql? STANDARD_HOSTED_ASSETS or region.eql? "eu-west-1" then "" else "-#{region}" end
-        "#{bucket}#{suffix}"
+        "#{bucket}#{suffix}/"
       end
 
       Contract String, String, String, String => AssetsHash

--- a/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/emr_job.rb
+++ b/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/emr_job.rb
@@ -166,9 +166,9 @@ module Snowplow
         # Prepare a bootstrap action based on the AMI version
         standard_assets_bucket = self.class.get_hosted_assets_bucket(STANDARD_HOSTED_ASSETS, config[:aws][:emr][:region])
         bootstrap_jar_location = if @legacy
-          "#{standard_assets_bucket}/common/emr/snowplow-ami3-bootstrap-0.1.0.sh"
+          "#{standard_assets_bucket}common/emr/snowplow-ami3-bootstrap-0.1.0.sh"
         else
-          "#{standard_assets_bucket}/common/emr/snowplow-ami4-bootstrap-0.2.0.sh"
+          "#{standard_assets_bucket}common/emr/snowplow-ami4-bootstrap-0.2.0.sh"
         end
         cc_version = get_cc_version(config[:enrich][:versions][:hadoop_enrich])
         @jobflow.add_bootstrap_action(Elasticity::BootstrapAction.new(bootstrap_jar_location, cc_version))


### PR DESCRIPTION
@alexanderdean thanks for fixing #2813

If I use the default configuration file for the EMR runner provided by snowplow:
```
...
buckets:
      assets: s3://snowplow-hosted-assets
...
```
...the S3 locations are not generated as expected. The reason for this is, that `config[:aws][:s3][:buckets][:assets]` seems to always to have a trailing slash included and so the string comparison fails in your new created function.

Code to clearify:
```
logger.debug "custom_assets_bucket CHECK"
logger.debug config[:aws][:s3][:buckets][:assets]
logger.debug STANDARD_HOSTED_ASSETS
logger.debug self.class.get_hosted_assets_bucket(config[:aws][:s3][:buckets][:assets], config[:aws][:emr][:region])
logger.debug self.class.get_hosted_assets_bucket(STANDARD_HOSTED_ASSETS, config[:aws][:emr][:region])
```

**Output**
```
D, [2016-07-28T11:34:49.487000 #12410] DEBUG -- : custom_assets_bucket CHECK
D, [2016-07-28T11:34:49.490000 #12410] DEBUG -- : s3://snowplow-hosted-assets/
D, [2016-07-28T11:34:49.491000 #12410] DEBUG -- : s3://snowplow-hosted-assets
D, [2016-07-28T11:34:49.494000 #12410] DEBUG -- : s3://snowplow-hosted-assets/
D, [2016-07-28T11:34:49.502000 #12410] DEBUG -- : s3://snowplow-hosted-assets-eu-central-1
```
**Output patched version**
```
D, [2016-07-28T12:38:09.485000 #12814] DEBUG -- : custom_assets_bucket CHECK
D, [2016-07-28T12:38:09.490000 #12814] DEBUG -- : s3://snowplow-hosted-assets/
D, [2016-07-28T12:38:09.494000 #12814] DEBUG -- : s3://snowplow-hosted-assets
D, [2016-07-28T12:38:09.498000 #12814] DEBUG -- : s3://snowplow-hosted-assets-eu-central-1/
D, [2016-07-28T12:38:09.502000 #12814] DEBUG -- : s3://snowplow-hosted-assets-eu-central-1/
```

Without this fix, the EMR step `Elasticity Scalding Step: Enrich Raw Events` fails at the step
`2016-07-28T10:00:14.395Z INFO Ensure step 2 jar file s3://snowplow-hosted-assets/3-enrich/scala-hadoop-enrich/snowplow-hadoop-enrich-1.7.0.jar`

This is basically the same problem like fetching the boostrapping files from another region.