### PR TITLE
Make Scala collector resolve variables in config file.

### DIFF
--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ScalaCollectorApp.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ScalaCollectorApp.scala
@@ -68,7 +68,7 @@ object ScalaCollector extends App {
     "Configuration file.") { (c, opt) =>
     val file = new File(c)
     if (file.exists) {
-      ConfigFactory.parseFile(file)
+      ConfigFactory.parseFile(file).resolve()
     } else {
       parser.usage("Configuration file \"%s\" does not exist".format(c))
       ConfigFactory.empty()


### PR DESCRIPTION
This pull request explicitly tells the Scala collector to resolve any variables in the config variable. This enables users to do things like referencing environment variables from the config, which is useful for things like hiding secrets or enabling multiple deployments of the same config.