### PR TITLE
Automatically create duplicates.events table from atomic.events

### DIFF
--- a/5-data-modeling/sql-runner/redshift/setup/deduplicate/setup.sql
+++ b/5-data-modeling/sql-runner/redshift/setup/deduplicate/setup.sql
@@ -21,4 +21,11 @@
 CREATE SCHEMA IF NOT EXISTS duplicates;
 
 -- Step 2: create or upgrade duplicates.events using the same definition as atomic.events
+
+-- Automatically re-create the duplicates.events table from the atomic.events schema:
+CREATE TABLE duplicates.events AS (
+  SELECT * FROM atomic.events WHERE 1 = 2
+);
+
+-- Conversely, you can manually create the schema from the atomic.events definition:
 -- https://github.com/snowplow/snowplow/blob/master/4-storage/redshift-storage/sql/atomic-def.sql


### PR DESCRIPTION
To ease the automation of the setup of de-duplication, we can automatically generate the duplicates.events table from the atomic.events table's schema. To do so without loading any data, we simple provide an always false conditional.
