### PR TITLE
StorageLoader: fix typo in S3Tasks.download_events

### DIFF
--- a/4-storage/storage-loader/lib/snowplow-storage-loader/s3_tasks.rb
+++ b/4-storage/storage-loader/lib/snowplow-storage-loader/s3_tasks.rb
@@ -38,7 +38,7 @@ module Snowplow
           config[:aws][:s3][:region],
           config[:aws][:access_key_id],
           config[:aws][:secret_access_key])
-        s3.host = region_to_safe_host([:aws][:s3][:region])
+        s3.host = region_to_safe_host(config[:aws][:s3][:region])
 
         # Get S3 location of In Bucket plus local directory
         in_location = Sluice::Storage::S3::Location.new(config[:aws][:s3][:buckets][:shredded][:good])


### PR DESCRIPTION
I'm new to Snowplow. It looks awesome. Trying to have it up and running.

We're using snowplow_emr_r83_bald_eagle_rc2.

Ran `./snowplow-storage-loader -c config.yaml`

Got the following error msg:

```
Downloading Snowplow events...
Unexpected error: no implicit conversion of Symbol into Integer
org/jruby/RubyArray.java:1457:in `[]'
uri:classloader:/storage-loader/lib/snowplow-storage-loader/s3_tasks.rb:41:in `download_events'
uri:classloader:/storage-loader/bin/snowplow-storage-loader:42:in `<main>'
org/jruby/RubyKernel.java:973:in `load'
uri:classloader:/META-INF/main.rb:1:in `<main>'
org/jruby/RubyKernel.java:955:in `require'
uri:classloader:/META-INF/main.rb:1:in `(root)'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1:in `<main>'
```

Checked the source code. Looks like that just needs a quick fix.

Meanwhile I guess I'll just try to use the latest release without this bug.
