### PR TITLE
Faster deduplication queries

### DIFF
--- a/5-data-modeling/sql-runner/redshift/sql/deduplicate/01-events.sql
+++ b/5-data-modeling/sql-runner/redshift/sql/deduplicate/01-events.sql
@@ -35,7 +35,22 @@ DROP TABLE IF EXISTS duplicates.tmp_events_id_remaining;
 CREATE TABLE duplicates.tmp_events_id
   DISTKEY (event_id)
   SORTKEY (event_id)
-AS (SELECT event_id, event_fingerprint FROM (SELECT event_id, event_fingerprint, COUNT(*) AS count FROM atomic.events WHERE event_fingerprint IS NOT NULL AND collector_tstamp > DATEADD(week, -4, CURRENT_DATE) GROUP BY 1,2) WHERE count > 1);
+AS (
+
+  SELECT event_id, event_fingerprint
+  FROM (
+
+    SELECT event_id, event_fingerprint, COUNT(*) AS count
+    FROM atomic.events
+    WHERE event_fingerprint IS NOT NULL
+      AND collector_tstamp > DATEADD(week, -4, CURRENT_DATE)
+    GROUP BY 1,2
+
+  )
+
+  WHERE count > 1
+
+);
 
 -- (b) create a new table with events that match these critera
 

--- a/5-data-modeling/sql-runner/redshift/sql/deduplicate/02-events-without-fingerprint.sql
+++ b/5-data-modeling/sql-runner/redshift/sql/deduplicate/02-events-without-fingerprint.sql
@@ -39,7 +39,21 @@ DROP TABLE IF EXISTS duplicates.tmp_events_id_remaining;
 CREATE TABLE duplicates.tmp_events_id
   DISTKEY (event_id)
   SORTKEY (event_id)
-AS (SELECT event_id FROM (SELECT event_id, COUNT(*) AS count FROM atomic.events WHERE collector_tstamp > DATEADD(week, -4, CURRENT_DATE) GROUP BY 1) WHERE count > 1);
+AS (
+
+  SELECT event_id
+  FROM (
+
+    SELECT event_id, COUNT(*) AS count
+    FROM atomic.events
+    WHERE collector_tstamp > DATEADD(week, -4, CURRENT_DATE)
+    GROUP BY 1
+
+  )
+
+  WHERE count > 1
+
+);
 
 -- (b) create a new table with these events and replicate the event fingerprint
 

--- a/5-data-modeling/sql-runner/redshift/sql/deduplicate/02-events-without-fingerprint.sql
+++ b/5-data-modeling/sql-runner/redshift/sql/deduplicate/02-events-without-fingerprint.sql
@@ -39,7 +39,7 @@ DROP TABLE IF EXISTS duplicates.tmp_events_id_remaining;
 CREATE TABLE duplicates.tmp_events_id
   DISTKEY (event_id)
   SORTKEY (event_id)
-AS (SELECT event_id FROM (SELECT event_id, COUNT(*) AS count FROM atomic.events GROUP BY 1) WHERE count > 1);
+AS (SELECT event_id FROM (SELECT event_id, COUNT(*) AS count FROM atomic.events WHERE collector_tstamp > DATEADD(week, -4, CURRENT_DATE) GROUP BY 1) WHERE count > 1);
 
 -- (b) create a new table with these events and replicate the event fingerprint
 
@@ -126,6 +126,7 @@ AS (
       ) AS custom_fingerprint
     FROM atomic.events
     WHERE event_id IN (SELECT event_id FROM duplicates.tmp_events_id)
+      AND collector_tstamp > DATEADD(week, -4, CURRENT_DATE)
   )
 
 );
@@ -135,7 +136,8 @@ AS (
 BEGIN;
 
   DELETE FROM atomic.events
-  WHERE event_id IN (SELECT event_id FROM duplicates.tmp_events_id);
+  WHERE event_id IN (SELECT event_id FROM duplicates.tmp_events_id)
+    AND collector_tstamp > DATEADD(week, -4, CURRENT_DATE);
 
   INSERT INTO atomic.events (
 

--- a/5-data-modeling/sql-runner/redshift/sql/deduplicate/03-example-unstruct.sql
+++ b/5-data-modeling/sql-runner/redshift/sql/deduplicate/03-example-unstruct.sql
@@ -39,7 +39,21 @@ DROP TABLE IF EXISTS duplicates.tmp_example_unstruct_id_remaining; -- todo: repl
 CREATE TABLE duplicates.tmp_example_unstruct_id -- todo: replace placeholder name
   DISTKEY (root_id)
   SORTKEY (root_id)
-AS (SELECT root_id FROM (SELECT root_id, COUNT(*) AS count FROM atomic.example_unstruct WHERE root_tstamp > DATEADD(week, -4, CURRENT_DATE) GROUP BY 1) WHERE count > 1); -- todo: replace placeholder name
+AS (
+
+  SELECT root_id
+  FROM (
+
+    SELECT root_id, COUNT(*) AS count
+    FROM atomic.example_unstruct
+    WHERE root_tstamp > DATEADD(week, -4, CURRENT_DATE)
+    GROUP BY 1
+
+  )
+
+  WHERE count > 1
+
+); -- todo: replace placeholder name
 
 -- (b) create a new table with these events and deduplicate as much as possible using GROUP BY
 

--- a/5-data-modeling/sql-runner/redshift/sql/deduplicate/03-example-unstruct.sql
+++ b/5-data-modeling/sql-runner/redshift/sql/deduplicate/03-example-unstruct.sql
@@ -39,7 +39,7 @@ DROP TABLE IF EXISTS duplicates.tmp_example_unstruct_id_remaining; -- todo: repl
 CREATE TABLE duplicates.tmp_example_unstruct_id -- todo: replace placeholder name
   DISTKEY (root_id)
   SORTKEY (root_id)
-AS (SELECT root_id FROM (SELECT root_id, COUNT(*) AS count FROM atomic.example_unstruct GROUP BY 1) WHERE count > 1); -- todo: replace placeholder name
+AS (SELECT root_id FROM (SELECT root_id, COUNT(*) AS count FROM atomic.example_unstruct WHERE root_tstamp > DATEADD(week, -4, CURRENT_DATE) GROUP BY 1) WHERE count > 1); -- todo: replace placeholder name
 
 -- (b) create a new table with these events and deduplicate as much as possible using GROUP BY
 
@@ -65,6 +65,7 @@ AS (
 
   FROM atomic.example_unstruct -- todo: replace placeholder name
   WHERE root_id IN (SELECT root_id FROM duplicates.tmp_example_unstruct_id) -- todo: replace placeholder name
+    AND root_tstamp > DATEADD(week, -4, CURRENT_DATE)
   GROUP BY 1,2,3,4,5,7,8,9 -- todo: add all remaining columns (except root_tstamp)
 
 );
@@ -73,7 +74,7 @@ AS (
 
 BEGIN;
 
-  DELETE FROM atomic.example_unstruct WHERE root_id IN (SELECT root_id FROM duplicates.tmp_example_unstruct_id); -- todo: replace placeholder name
+  DELETE FROM atomic.example_unstruct WHERE root_id IN (SELECT root_id FROM duplicates.tmp_example_unstruct_id) AND root_tstamp > DATEADD(week, -4, CURRENT_DATE); -- todo: replace placeholder name
   INSERT INTO atomic.example_unstruct (SELECT * FROM duplicates.tmp_example_unstruct); -- todo: replace placeholder name
 
 COMMIT;


### PR DESCRIPTION
Following @bogaert [suggestion on Discourse](http://discourse.snowplowanalytics.com/t/making-sql-data-models-incremental-to-improve-performance-tutorial), I was able to reduce the deduplication runtime by 90% restricting table scans for the previous 4 weeks. 99.9% of our duplicates occur within that time frame.