### PR TITLE
Fix for #3019

### DIFF
--- a/4-storage/kinesis-elasticsearch-sink/src/test/scala/com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch/SnowplowElasticsearchEmitterSpec.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/test/scala/com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch/SnowplowElasticsearchEmitterSpec.scala
@@ -16,6 +16,10 @@ package com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch
 // Java
 import java.util.Properties
 
+import com.snowplowanalytics.snowplow.storage.kinesis.elasticsearch.clients.{ElasticsearchSender, IElasticsearchSender}
+
+import scala.collection.mutable.ListBuffer
+
 // AWS libs
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 
@@ -40,6 +44,11 @@ import org.json4s._
 import org.json4s.jackson.JsonMethods._
 import org.json4s.JsonDSL._
 
+// Logging
+import org.apache.commons.logging.{
+  LogFactory
+}
+
 // Specs2
 import org.specs2.mutable.Specification
 import org.specs2.scalaz.ValidationMatchers
@@ -51,6 +60,24 @@ import sinks._
  * Tests Shredder
  */
 class SnowplowElasticsearchEmitterSpec extends Specification with ValidationMatchers {
+
+  private val Log = LogFactory.getLog(getClass)
+
+  class MockElasticsearchSender extends ElasticsearchSender {
+    var sentRecords: List[(String, Validation[List[String], ElasticsearchObject])] = List()
+    var callCount: Int = 0
+    val calls: ListBuffer[List[(String, Validation[List[String], ElasticsearchObject])]] = new ListBuffer
+
+    override def sendToElasticsearch(records: List[(String, Validation[List[String], ElasticsearchObject])]) = {
+      sentRecords = sentRecords ::: records
+      callCount += 1
+      calls += records
+      List()
+    }
+
+    override def close() = {}
+
+  }
 
   "The emit method" should {
     "return all invalid records" in {
@@ -69,6 +96,126 @@ class SnowplowElasticsearchEmitterSpec extends Specification with ValidationMatc
       val actual = eem.emit(ub)
 
       actual must_== List(invalidInput).asJava
+    }
+
+    "send multiple records in seperate requests where single record size > buffer bytes size" in {
+      val props = new Properties
+      props.setProperty(KinesisConnectorConfiguration.PROP_BUFFER_BYTE_SIZE_LIMIT, "1000")
+
+      val kcc = new KinesisConnectorConfiguration(props, new DefaultAWSCredentialsProviderChain)
+
+
+      val ess = new MockElasticsearchSender
+      val eem = new SnowplowElasticsearchEmitter(kcc, None, new StdouterrSink, None, 60000, Some(ess))
+
+      val validInput: EmitterInput = "good" -> new ElasticsearchObject("index" * 10000, "type", "{}").success
+
+      val input = List.fill(50)(validInput)
+
+      val bmb = new BasicMemoryBuffer[EmitterInput](kcc, input)
+      val ub = new UnmodifiableBuffer[EmitterInput](bmb)
+
+      eem.emit(ub)
+
+      ess.sentRecords mustEqual input
+      ess.callCount mustEqual 50
+      forall (ess.calls) { c => c.length mustEqual 1 }
+    }
+
+    "send a single record in 1 request where record size > buffer bytes size " in {
+      val props = new Properties
+      props.setProperty(KinesisConnectorConfiguration.PROP_BUFFER_BYTE_SIZE_LIMIT, "1000")
+
+      val kcc = new KinesisConnectorConfiguration(props, new DefaultAWSCredentialsProviderChain)
+
+
+      val ess = new MockElasticsearchSender
+      val eem = new SnowplowElasticsearchEmitter(kcc, None, new StdouterrSink, None, 60000, Some(ess))
+
+      val validInput: EmitterInput = "good" -> new ElasticsearchObject("index" * 10000, "type", "{}").success
+
+      val input = List(validInput)
+
+      val bmb = new BasicMemoryBuffer[EmitterInput](kcc, input)
+      val ub = new UnmodifiableBuffer[EmitterInput](bmb)
+
+      eem.emit(ub)
+
+      ess.sentRecords mustEqual input
+      ess.callCount mustEqual 1
+      forall (ess.calls) { c => c.length mustEqual 1 }
+    }
+
+    "send multiple records in 1 request where total byte size < buffer bytes size" in {
+      val props = new Properties
+      props.setProperty(KinesisConnectorConfiguration.PROP_BUFFER_BYTE_SIZE_LIMIT, "1048576")
+
+      val kcc = new KinesisConnectorConfiguration(props, new DefaultAWSCredentialsProviderChain)
+
+      val ess = new MockElasticsearchSender
+      val eem = new SnowplowElasticsearchEmitter(kcc, None, new StdouterrSink, None, 60000, Some(ess))
+
+      val validInput: EmitterInput = "good" -> new ElasticsearchObject("index", "type", "{}").success
+
+      val input = List.fill(50)(validInput)
+
+      val bmb = new BasicMemoryBuffer[EmitterInput](kcc, input)
+      val ub = new UnmodifiableBuffer[EmitterInput](bmb)
+
+      eem.emit(ub)
+
+      ess.sentRecords mustEqual input
+      ess.callCount mustEqual 1
+      forall (ess.calls) { c => c.length mustEqual 50 }
+    }
+
+    "send a single record in 1 request where single record size < buffer bytes size" in {
+      val props = new Properties
+      props.setProperty(KinesisConnectorConfiguration.PROP_BUFFER_BYTE_SIZE_LIMIT, "1048576")
+
+      val kcc = new KinesisConnectorConfiguration(props, new DefaultAWSCredentialsProviderChain)
+
+
+      val ess = new MockElasticsearchSender
+      val eem = new SnowplowElasticsearchEmitter(kcc, None, new StdouterrSink, None, 60000, Some(ess))
+
+      val validInput: EmitterInput = "good" -> new ElasticsearchObject("index", "type", "{}").success
+
+      val input = List(validInput)
+
+      val bmb = new BasicMemoryBuffer[EmitterInput](kcc, input)
+      val ub = new UnmodifiableBuffer[EmitterInput](bmb)
+
+      eem.emit(ub)
+
+      ess.sentRecords mustEqual input
+      ess.callCount mustEqual 1
+      forall (ess.calls) { c => c.length mustEqual 1 }
+    }
+
+    "send multiple records in batches where single record byte size < buffer size and total byte size > buffer size" in {
+      val props = new Properties
+      props.setProperty(KinesisConnectorConfiguration.PROP_BUFFER_BYTE_SIZE_LIMIT, "200")
+
+      val kcc = new KinesisConnectorConfiguration(props, new DefaultAWSCredentialsProviderChain)
+
+
+      val ess = new MockElasticsearchSender
+      val eem = new SnowplowElasticsearchEmitter(kcc, None, new StdouterrSink, None, 60000, Some(ess))
+
+      // record size is 95 bytes
+      val validInput: EmitterInput = "good" -> new ElasticsearchObject("index", "type", "{}").success
+
+      val input = List.fill(20)(validInput)
+
+      val bmb = new BasicMemoryBuffer[EmitterInput](kcc, input)
+      val ub = new UnmodifiableBuffer[EmitterInput](bmb)
+
+      eem.emit(ub)
+
+      ess.sentRecords mustEqual input
+      ess.callCount mustEqual 10 // 10 buffers of 2 records each
+      forall (ess.calls) { c => c.length mustEqual 2 }
     }
   }
 


### PR DESCRIPTION
Fix for #3019 

Added tests to cover the various cases for byte size buffering, and refactored `ElasticsearchSender` out of `SnowplowElasticsearchEmitter` so a mock can be swapped in for testing.

In fixing the buffering routine I rewrote the recursive function `#splitBuffer` as a simple while loop. To me this is much clearer and more readable but open to disagreement on that.