### PR TITLE
Fixes #3085 - EmrEtlRunner : misnamed CloudFront-like conversion

### DIFF
--- a/3-enrich/emr-etl-runner/config/config.yml.sample
+++ b/3-enrich/emr-etl-runner/config/config.yml.sample
@@ -13,6 +13,7 @@ aws:
           - ADD HERE          # e.g. s3://my-in-bucket
           - ADD HERE
         processing: ADD HERE
+        retry: ADD HERE
         archive: ADD HERE    # e.g. s3://my-archive-bucket/raw
       enriched:
         good: ADD HERE       # e.g. s3://my-out-bucket/enriched/good

--- a/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/s3_tasks.rb
+++ b/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/s3_tasks.rb
@@ -77,7 +77,7 @@ module Snowplow
             # This will convert Beanstalk epoch timestamps to our CloudFront-like yyyy-MM-dd-HH
             final_name, final_extn =get_final_name_and_extension( filepath, basename, instance)
 
-            Monitoring::Logging::logger.debug "final_name:'#{final_name}', final_extn:'#{final_extn}'"
+            Monitoring::Logging::logger.debug "Instance = #{instance}, final_name:'#{final_name}', final_extn:'#{final_extn}'"
 
             return (final_extn.eql? RETRY_EXT) ?
                 (RETRY_EXT + '/' + final_name ) :


### PR DESCRIPTION
The converted datetime doesnt match every time with the original timestamp.
A "reverse conversion" is done afterwards.

It iterates some times on the same filename/timestamps and send the file to a retry folder if the conversion continues to fail.

The rejected file is processed in the next run.
 
Fixes #3085

[s3_tasks_spec.rb](https://github.com/snowplow/snowplow/blob/master/3-enrich/emr-etl-runner/spec/snowplow-emr-etl-runner/s3_tasks_spec.rb) passes :ok_hand: