### PR TITLE
Gcp snowplow

### DIFF
--- a/2-collectors/scala-stream-collector/examples/config.hocon.sample
+++ b/2-collectors/scala-stream-collector/examples/config.hocon.sample
@@ -53,6 +53,7 @@ collector {
     # Sinks currently supported are:
     # 'kinesis' for writing Thrift-serialized records to a Kinesis stream
     # 'kafka' for writing Thrift-serialized records to kafka
+    # 'gcpubsub' for writing Thrift-serialized records to Google Cloud Pub/Sub
     # 'stdout' for writing Base64-encoded Thrift-serialized records to stdout
     #    Recommended settings for 'stdout' so each line printed to stdout
     #    is a serialized record are:
@@ -99,6 +100,18 @@ collector {
       topic {
         good: "{{collectorKafkaTopicGoodName}}"
         bad: "{{collectorKafkaTopicBadName}}"
+      }
+    }
+
+    gcpubsub {
+
+      # this is the project ID inside of which your collector will be running
+      google-project-id: "{{collectorPubSubProjectId}}"
+
+      # Data will be stored in the following topics (they must have been created ahead-of-time)
+      topic {
+        good: "{{collectorPubSubTopicGoodName}}"
+        bad: "{{collectorPubSubTopicBadName}}"
       }
     }
 

--- a/2-collectors/scala-stream-collector/project/BuildSettings.scala
+++ b/2-collectors/scala-stream-collector/project/BuildSettings.scala
@@ -58,7 +58,14 @@ object BuildSettings {
     // Executable jarfile
     assemblyOption in assembly ~= { _.copy(prependShellScript = Some(defaultShellScript)) },
     // Name it as an executable
-    jarName in assembly := { s"${name.value}-${version.value}" }
+    jarName in assembly := { s"${name.value}-${version.value}" },
+    //merge strategy for fixing netty conflict
+    mergeStrategy in assembly <<= (mergeStrategy in assembly) {
+        (old) => {
+            case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.discard
+            case x => old(x)
+        }
+      }
   )
 
   lazy val buildSettings = basicSettings ++ scalifySettings ++ sbtAssemblySettings

--- a/2-collectors/scala-stream-collector/project/Dependencies.scala
+++ b/2-collectors/scala-stream-collector/project/Dependencies.scala
@@ -34,6 +34,7 @@ object Dependencies {
     val yodaTime         = "2.1"
     val yodaConvert      = "1.2"
     val kafka            = "0.10.1.0"
+    val gcpPubsub        = "0.9.3-alpha"
     // Scala
     val snowplowCommonEnrich = "0.22.0"
     val igluClient       = "0.3.2"
@@ -55,11 +56,12 @@ object Dependencies {
 
   object Libraries {
     // Java
-    val mimepull         = "org.jvnet.mimepull"    %  "mimepull"                  % V.mimepull
-    val awsSdk           = "com.amazonaws"         %  "aws-java-sdk"              % V.awsSdk
-    val yodaTime         = "joda-time"             %  "joda-time"                 % V.yodaTime
-    val yodaConvert      = "org.joda"              %  "joda-convert"              % V.yodaConvert
-    val kafkaClients     = "org.apache.kafka"      %  "kafka-clients"             % V.kafka
+    val mimepull         = "org.jvnet.mimepull"    %  "mimepull"                        % V.mimepull
+    val awsSdk           = "com.amazonaws"         %  "aws-java-sdk"                    % V.awsSdk
+    val yodaTime         = "joda-time"             %  "joda-time"                       % V.yodaTime
+    val yodaConvert      = "org.joda"              %  "joda-convert"                    % V.yodaConvert
+    val kafkaClients     = "org.apache.kafka"      %  "kafka-clients"                   % V.kafka
+    val gcpPubsub        = "com.google.cloud"      %  "google-cloud-pubsub"             % V.gcpPubsub
 
     // Scala
     // Exclude netaporter to prevent conflicting cross-version suffixes for shapeless

--- a/2-collectors/scala-stream-collector/project/ScalaCollectorBuild.scala
+++ b/2-collectors/scala-stream-collector/project/ScalaCollectorBuild.scala
@@ -51,7 +51,8 @@ object ScalaCollectorBuild extends Build {
         Libraries.snowplowRawEvent,
         Libraries.collectorPayload,
         Libraries.json4sJackson,
-        Libraries.kafkaClients
+        Libraries.kafkaClients,
+        Libraries.gcpPubsub
       )
     )
 }

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ScalaCollectorApp.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ScalaCollectorApp.scala
@@ -95,6 +95,11 @@ object ScalaCollector extends App {
       val bad  = new KafkaSink(collectorConfig, InputType.Bad)
       CollectorSinks(good, bad)
     }
+    case Sink.PubSub => {
+      val good = new PubSubSink(collectorConfig, InputType.Good)
+      val bad  = new PubSubSink(collectorConfig, InputType.Bad)
+      CollectorSinks(good, bad)
+    }
     case Sink.Stdout  => {
       val good = new StdoutSink(InputType.Good)
       val bad = new StdoutSink(InputType.Bad)
@@ -143,7 +148,7 @@ object Helper {
 // store this enumeration.
 object Sink extends Enumeration {
   type Sink = Value
-  val Kinesis, Kafka, Stdout, Test = Value
+  val Kinesis, Kafka, PubSub, Stdout, Test = Value
 }
 
 // How a collector should set cookies
@@ -180,6 +185,7 @@ class CollectorConfig(config: Config) {
     case "kafka" => Sink.Kafka
     case "stdout" => Sink.Stdout
     case "test" => Sink.Test
+    case "gcpubsub" => Sink.PubSub
     case _ => throw new RuntimeException("collector.sink.enabled unknown.")
   }
 
@@ -205,6 +211,12 @@ class CollectorConfig(config: Config) {
   private val kafkaTopic = kafka.getConfig("topic")
   val kafkaTopicGoodName = kafkaTopic.getString("good")
   val kafkaTopicBadName = kafkaTopic.getString("bad")
+
+  private val gcpubsub = sink.getConfig("gcpubsub")
+  val googleProjectId = gcpubsub.getString("google-project-id")
+  private val gcpubsubTopic = gcpubsub.getConfig("topic")
+  val pubsubTopicGoodName = gcpubsubTopic.getString("good")
+  val pubsubTopicBadName = gcpubsubTopic.getString("bad")
 
   private val buffer = sink.getConfig("buffer")
   val byteLimit = buffer.getInt("byte-limit")

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/sinks/PubSubSink.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/sinks/PubSubSink.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2013-2016 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.collectors
+package scalastream
+package sinks
+
+// Java
+import java.util.Properties
+import java.io.FileInputStream
+
+// Scala
+import scala.collection.JavaConversions._
+
+// PubSub
+import com.google.cloud.pubsub.spi.v1.Publisher
+import com.google.pubsub.v1.TopicName
+import com.google.pubsub.v1.PubsubMessage
+import com.google.protobuf.ByteString
+
+
+// Config
+import com.typesafe.config.Config
+
+// Logging
+import org.slf4j.LoggerFactory
+
+
+/**
+ * PubSub Sink for the Scala collector
+ */
+class PubSubSink(config: CollectorConfig, inputType: InputType.InputType) extends AbstractSink {
+
+  import log.{error, debug, info, trace}
+
+  // not used, but required for this class to implement AbstractSink
+  val MaxBytes = 1000000L
+
+  private val topicName = inputType match {
+    case InputType.Good => config.pubsubTopicGoodName
+    case InputType.Bad  => config.pubsubTopicBadName
+  }
+
+  private val pubSubPublisher = createPublisher
+
+  /**
+   * Instantiates a Publisher on an existing topic
+   * with the given configuration options. If the name isn't correct, this will fail
+   *
+   * @return a PubSub Topic object
+   */
+  private def createPublisher: Publisher =
+    Publisher.newBuilder(
+        TopicName.create(s"${config.googleProjectId}",  s"$topicName")
+    ).build
+
+  /**
+   * Convert event bytes to PubsubMessage to be published
+   * @param event Event to be converted
+   * @return PubsubMessage instance
+   */
+  private def eventToPubsubMessage(event: Array[Byte]): PubsubMessage = {
+    PubsubMessage.newBuilder
+      .setData(ByteString.copyFrom(event))
+      .build
+  }
+
+  /**
+   * Store raw events to the topic
+   *
+   * @param events The list of events to send
+   * @param key Not used.
+   */
+  override def storeRawEvents(events: List[Array[Byte]], key: String) = {
+    debug(s"Writing ${events.size} Thrift records to PubSub topic ${topicName}")
+    events.foreach(event => pubSubPublisher.publish(eventToPubsubMessage(event)))
+    Nil
+  }
+
+  override def getType = Sink.PubSub
+}

--- a/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
+++ b/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
@@ -96,6 +96,16 @@ collector {
       }
     }
 
+    gcpubsub {
+      google-auth-path: "/path/to/credentials/file.json"
+      google-project-id: "projectid-123456"
+
+      topic {
+        good: "good-topic"
+        bad: "bad-topic"
+      }
+    }
+
     buffer {
       byte-limit: 4000000 # 4MB
       record-limit: 500 # 500 records

--- a/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/PostSpec.scala
+++ b/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/PostSpec.scala
@@ -96,6 +96,17 @@ collector {
       }
     }
 
+    gcpubsub {
+      google-auth-path: "/path/to/credentials/file.json"
+      google-project-id: "projectid-123456"
+
+      topic {
+        good: "good-topic"
+        bad: "bad-topic"
+      }
+    }
+
+
     buffer {
       byte-limit: 4000000 # 4MB
       record-limit: 500 # 500 records

--- a/3-enrich/stream-enrich/examples/config.hocon.sample
+++ b/3-enrich/stream-enrich/examples/config.hocon.sample
@@ -24,6 +24,7 @@ enrich {
   # Sinks currently supported are:
   # 'kinesis' for writing enriched events to one Kinesis stream and invalid events to another.
   # 'kafka' for writing enriched events to one Kafka topic and invalid events to another.
+  # 'pubsub' for writing enriched events to one Cloud Pubsub topic and invalid events to another.
   # 'stdouterr' for writing enriched events to stdout and invalid events to stderr.
   #    Using "sbt assembly" and "java -jar" is recommended to disable sbt
   #    logging.
@@ -46,11 +47,15 @@ enrich {
     brokers: "{{enrichKafkaBrokers}}"
   }
 
+  pubsub {
+    projectId: "{{gcpProjectId}}"
+  }
+
   streams {
     in: {
       raw: "{{enrichStreamsInRaw}}"
 
-      # Maximum number of records to get from Kinesis per call to GetRecords
+      # Maximum number of records to get from Kinesis or PubSub per call to GetRecords
       maxRecords: 10000
 
       # After enrichment, are accumulated in a buffer before being sent to Kinesis.

--- a/3-enrich/stream-enrich/project/Dependencies.scala
+++ b/3-enrich/stream-enrich/project/Dependencies.scala
@@ -36,6 +36,8 @@ object Dependencies {
     val awsSdk               = "1.6.11"
     val kinesisClient        = "1.6.1"
     val kafkaClients         = "0.10.1.0"
+    val gcpPubsub            = "0.9.3-alpha"
+    val gcpDatastore         = "0.9.3-beta"
     // Scala
     val argot                = "1.0.1"
     val config               = "1.0.2"
@@ -66,6 +68,8 @@ object Dependencies {
     val awsSdk               = "com.amazonaws"              %  "aws-java-sdk"             % V.awsSdk
     val kinesisClient        = "com.amazonaws"              %  "amazon-kinesis-client"    % V.kinesisClient
     val kafkaClients         = "org.apache.kafka"           %  "kafka-clients"            % V.kafkaClients
+    val gcpPubsub            = "com.google.cloud"           %  "google-cloud-pubsub"      % V.gcpPubsub
+    val gcpDatastore         = "com.google.cloud"           %  "google-cloud-datastore"   % V.gcpDatastore
     // Scala
     val argot                = "org.clapper"                %% "argot"                    % V.argot
     val config               = "com.typesafe"               %  "config"                   % V.config

--- a/3-enrich/stream-enrich/project/SnowplowKinesisEnrichBuild.scala
+++ b/3-enrich/stream-enrich/project/SnowplowKinesisEnrichBuild.scala
@@ -49,7 +49,9 @@ object SnowplowStreamEnrichBuild extends Build {
         Libraries.kinesisClient,
         Libraries.igluClient,
         Libraries.snowplowTracker,
-        Libraries.kafkaClients
+        Libraries.kafkaClients,
+        Libraries.gcpPubsub,
+        Libraries.gcpDatastore
         // Add your additional libraries here (comma-separated)...
       )
     )

--- a/3-enrich/stream-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/kinesis/sinks/PubsubSink.scala
+++ b/3-enrich/stream-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/kinesis/sinks/PubsubSink.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2013-2016 Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache
+ * License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.
+ *
+ * See the Apache License Version 2.0 for the specific language
+ * governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich
+package kinesis
+package sinks
+
+// Java
+import java.util.Properties
+
+// Pubsub
+import com.google.cloud.pubsub.spi.v1.Publisher
+import com.google.pubsub.v1.TopicName
+import com.google.pubsub.v1.PubsubMessage
+import com.google.protobuf.ByteString
+
+
+// Logging
+import org.slf4j.LoggerFactory
+
+// Tracker
+import com.snowplowanalytics.snowplow.scalatracker.Tracker
+
+/**
+ * Pubsub Sink for Scala enrichment
+ */
+class PubsubSink(config: KinesisEnrichConfig,
+    inputType: InputType.InputType, tracker: Option[Tracker]) extends ISink {
+
+  private lazy val log = LoggerFactory.getLogger(getClass())
+  import log.{error, debug, info, trace}
+
+  private val topicName = inputType match {
+    case InputType.Good => config.enrichedOutStream
+    case InputType.Bad => config.badOutStream
+  }
+
+  private val pubsubPublisher = createPublisher(config)
+
+  /**
+   * Side-effecting function to store the EnrichedEvent
+   * to the given output stream.
+   *
+   * EnrichedEvent takes the form of a tab-delimited
+   * String until such time as https://github.com/snowplow/snowplow/issues/211
+   * is implemented.
+   *
+   * This method blocks until the request has finished.
+   *
+   * @param events List of events together with their partition keys
+   * @return whether to send the stored events to Pubsub
+   */
+  def storeEnrichedEvents(events: List[(String, String)]): Boolean = {
+
+    // Log BadRows
+    inputType match {
+      case InputType.Good => None
+      case InputType.Bad  => events.foreach(e => debug(s"BadRow: ${e._1}"))
+    }
+
+    for ((value, _) <- events) {
+      pubsubPublisher.publish(
+        PubsubMessage.newBuilder
+          .setData(ByteString.copyFrom(value.getBytes))
+          .build
+      )
+    }
+
+    true // Always return true as our flush does nothing
+  }
+
+  /**
+   * Blocking method to send all stored records to Pubsub
+   * For Pubsub this method doesn't do anything (we have
+   * handed this off to the PubsubPublisher).
+   */
+  def flush() {
+  }
+
+  /**
+   * Create a topic publisher instance, based on the config file settings
+   * @param config The config file settings
+   * @return A Publisher instance
+   */
+  private def createPublisher(config: KinesisEnrichConfig): Publisher =
+    Publisher.newBuilder(
+        TopicName.create(s"${config.projectId}",  s"$topicName")
+    ).build
+
+}

--- a/3-enrich/stream-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/kinesis/sources/PubsubSource.scala
+++ b/3-enrich/stream-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/kinesis/sources/PubsubSource.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2013-2016 Snowplow Analytics Ltd.
+ * All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache
+ * License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.
+ *
+ * See the Apache License Version 2.0 for the specific language
+ * governing permissions and limitations there under.
+ */
+package com.snowplowanalytics
+package snowplow
+package enrich
+package kinesis
+package sources
+
+// Java
+import java.net.InetAddress
+import java.util.{Properties,UUID}
+
+// Logging
+import org.slf4j.LoggerFactory
+
+// Pubsub
+import com.google.cloud.pubsub.spi.v1.{SubscriberClient,SubscriberSettings}
+import com.google.pubsub.v1.{
+  TopicName,
+  PubsubMessage,
+  SubscriptionName,
+  PullRequest,
+  ReceivedMessage}
+
+// Scala
+import scala.collection.JavaConverters._
+import org.joda.time.Duration
+
+// Iglu
+import iglu.client.Resolver
+
+// Snowplow events and enrichment
+import common.enrichments.EnrichmentRegistry
+
+// Tracker
+import com.snowplowanalytics.snowplow.scalatracker.Tracker
+
+/**
+ * Source to read events from a GCP Pub/Sub topic
+ */
+class PubsubSource(config: KinesisEnrichConfig, igluResolver: Resolver, enrichmentRegistry: EnrichmentRegistry, tracker: Option[Tracker])
+    extends AbstractSource(config, igluResolver, enrichmentRegistry, tracker) {
+
+  lazy val log = LoggerFactory.getLogger(getClass())
+  import log.{error, debug, info, trace}
+
+  /**
+   * Never-ending processing loop over source stream.
+   */
+  def run {
+    val workerId = InetAddress.getLocalHost().getCanonicalHostName() +
+      ":" + UUID.randomUUID()
+    info("Using workerId: " + workerId)
+
+    val subscriber = getTopicSubscriber(config)
+    val subscriptionName = SubscriptionName.create(s"${config.projectId}", s"${config.rawInStream}")
+    val pullRequest = getPullRequest(config, subscriber)
+
+    info(s"Processing raw input Pubsub topic: ${config.rawInStream}")
+
+    while (true) {
+      val acksAndBytes = subscriber.pull(pullRequest)
+        .getReceivedMessagesList
+        .asScala
+        .toList
+        .map(getDataAndAckId(_)) // Get the values
+
+      val (recordValues, toAck) = acksAndBytes.unzip
+
+      subscriber.acknowledge(subscriptionName, toAck.asJava)
+      enrichAndStoreEvents(recordValues)
+    }
+  }
+
+  /**
+   * Get received message data and ack id
+   * @param rcvdMessage received message instance
+   * @return tuple with received message bytes and ack id
+   */
+  private def getDataAndAckId(rcvdMessage: ReceivedMessage): (Array[Byte], String) =
+    (rcvdMessage.getMessage.getData.toByteArray, rcvdMessage.getAckId)
+
+  /**
+   * Get the a subscriber to the Pub/Sub topic, based on the config file
+   * @param config The config file settings
+   * @return A topic subscriber instance
+   */
+  private def getTopicSubscriber(config: KinesisEnrichConfig): SubscriberClient = {
+    val settings = createSettings(config)
+    SubscriberClient.create(settings) 
+  }
+
+  /**
+   * Create settings to instantiate the topic subscriber, based on the config file
+   * @param config The config file settings
+   * @return The topic subscriber settings
+   */
+  private def createSettings(config: KinesisEnrichConfig): SubscriberSettings = {
+    val subSettingsBuilder = SubscriberSettings.defaultBuilder()
+    subSettingsBuilder
+      .createSubscriptionSettings()
+      .getRetrySettingsBuilder()
+      .setTotalTimeout(Duration.millis(30000))
+
+    subSettingsBuilder.build
+  }
+  
+  /**
+   * Create the pull request object, needed to pull messages from the topic
+   * @param config The config file settings
+   * @param subscriberClient The topic subscriber instance
+   * @return A Pull Request instance
+   */
+  private def getPullRequest(config: KinesisEnrichConfig, subscriberClient: SubscriberClient): PullRequest = {
+    val name = SubscriptionName.create(s"${config.projectId}", s"${config.rawInStream}")
+    PullRequest.newBuilder()
+      .setSubscriptionWithSubscriptionName(name)
+      .setMaxMessages(config.maxRecords) 
+      .build
+  }
+
+}

--- a/3-enrich/stream-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/package.scala
+++ b/3-enrich/stream-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/package.scala
@@ -33,11 +33,11 @@ package object kinesis {
    */
   object Source extends Enumeration {
     type Source = Value
-    val Kafka, Kinesis, Stdin, Test = Value
+    val Kafka, Kinesis, Pubsub, Stdin, Test = Value
   }
 
   object Sink extends Enumeration {
     type Sink = Value
-    val Kafka, Kinesis, Stdouterr, Test = Value
+    val Kafka, Kinesis, Pubsub, Stdouterr, Test = Value
   }
 }


### PR DESCRIPTION
- [x] Add Pub/Sub as a sink for the Scala Stream Collector
- [x] Change the example hocon for the Scala Stream Collector, to include GCP configs
- [x] Add Pub/Sub as a sink for Stream Enrich
- [x] Add Pub/Sub as a source for Stream Enrich
- [x] Change the example hocon for Stream Enrich, to include GCP configs
- [x] Enable retrieval of enrichments and iglu resolvers from Cloud Datastore
- [ ] Add more detailed configurations for the sinks and sources (for example allowing Ack Policies other than the default)