### PR TITLE
Event Manifest Populator: set visible_to_all_users flag to true

### DIFF
--- a/5-data-modeling/event-manifest-populator/run.py
+++ b/5-data-modeling/event-manifest-populator/run.py
@@ -186,6 +186,7 @@ def run_emr(args):
         steps=steps,
         job_flow_role="EMR_EC2_DefaultRole",
         service_role="EMR_DefaultRole",
+        visible_to_all_users=True,
         api_params={
             'ReleaseLabel': 'emr-5.4.0',
             'Applications.member.1.Name': 'Spark',
@@ -218,6 +219,10 @@ if __name__ == "__main__":
         'resolver',
         type=str,
         help="Local path to Iglu resolver JSON configuration")
+    parser_run_emr.add_argument(
+        'log_path',
+        type=str,
+        help="S3 Log path")
     parser_run_emr.add_argument(
         '--since',
         required=False,


### PR DESCRIPTION
**Event Manifest Populator script**
- Adds a `log_path` argument, which was actually already implemented
- Sets the `visible_to_all_users` flag to `True`, to allow all users to see the EMR job on the console when it runs from an IAM role