### PR TITLE
Add HTTPS Support for Elasticsearch Sink

### DIFF
--- a/4-storage/kinesis-elasticsearch-sink/examples/config.hocon.sample
+++ b/4-storage/kinesis-elasticsearch-sink/examples/config.hocon.sample
@@ -85,7 +85,7 @@ sink {
   elasticsearch {
 
     # Events are indexed using an Elasticsearch Client
-    # - type: http or transport (will default to transport)
+    # - type: http, https, or transport (will default to transport)
     # - endpoint: the cluster endpoint
     # - port: the port the cluster can be accessed on
     #   - for http this is usually 9200

--- a/4-storage/kinesis-elasticsearch-sink/project/Dependencies.scala
+++ b/4-storage/kinesis-elasticsearch-sink/project/Dependencies.scala
@@ -21,6 +21,7 @@ object Dependencies {
     "Snowplow Analytics Maven snapshot repo" at "http://maven.snplow.com/snapshots/",
     // For Scalazon
     "BintrayJCenter"                         at "http://jcenter.bintray.com",
+    "Twitter maven repo"                     at "http://maven.twttr.com/",
     // For user-agent-utils
     "user-agent-utils repo"                  at "https://raw.github.com/HaraldWalker/user-agent-utils/mvn-repo/"
   )

--- a/4-storage/kinesis-elasticsearch-sink/src-compat/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/generated/ElasticsearchSenderHTTP_1x.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src-compat/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/generated/ElasticsearchSenderHTTP_1x.scala
@@ -74,7 +74,8 @@ class ElasticsearchSenderHTTP(
   tracker: Option[Tracker] = None,
   maxConnectionWaitTimeMs: Long = 60000,
   connTimeout: Int,
-  readTimeout: Int
+  readTimeout: Int,
+  httpProtocol: String = "http"
 ) extends ElasticsearchSender {
 
   private val Log = LogFactory.getLog(getClass)
@@ -87,7 +88,7 @@ class ElasticsearchSenderHTTP(
    */
   private val factory: JestClientFactory = new JestClientFactory()
   factory.setHttpClientConfig(new HttpClientConfig
-    .Builder("http://" + configuration.ELASTICSEARCH_ENDPOINT + ":" + configuration.ELASTICSEARCH_PORT)
+    .Builder(httpProtocol + "://" + configuration.ELASTICSEARCH_ENDPOINT + ":" + configuration.ELASTICSEARCH_PORT)
     .multiThreaded(true)
     .discoveryEnabled(false)
     .maxConnectionIdleTime(30L, TimeUnit.SECONDS)

--- a/4-storage/kinesis-elasticsearch-sink/src-compat/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/generated/ElasticsearchSenderHTTP_2x.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src-compat/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/generated/ElasticsearchSenderHTTP_2x.scala
@@ -74,7 +74,8 @@ class ElasticsearchSenderHTTP(
   tracker: Option[Tracker] = None,
   maxConnectionWaitTimeMs: Long = 60000,
   connTimeout: Int,
-  readTimeout: Int
+  readTimeout: Int,
+  httpProtocol: String = "http"
 ) extends ElasticsearchSender {
 
   private val Log = LogFactory.getLog(getClass)
@@ -86,8 +87,9 @@ class ElasticsearchSenderHTTP(
    * Prepare the elasticsearch client
    */
   private val factory: JestClientFactory = new JestClientFactory()
+
   factory.setHttpClientConfig(new HttpClientConfig
-    .Builder("http://" + configuration.ELASTICSEARCH_ENDPOINT + ":" + configuration.ELASTICSEARCH_PORT)
+    .Builder(httpProtocol + "://" + configuration.ELASTICSEARCH_ENDPOINT + ":" + configuration.ELASTICSEARCH_PORT)
     .multiThreaded(true)
     .discoveryEnabled(false)
     .maxConnectionIdleTime(30L, TimeUnit.SECONDS)

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchSinkApp.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/ElasticsearchSinkApp.scala
@@ -155,8 +155,8 @@ object ElasticsearchSinkApp extends App {
       }
 
       lazy val elasticsearchSender: ElasticsearchSender = (
-        if (clientType == "http") {
-          new ElasticsearchSenderHTTP(finalConfig, None, maxConnectionTime, connTimeout, readTimeout)
+        if ((clientType == "http") || (clientType == "https")){
+          new ElasticsearchSenderHTTP(finalConfig, None, maxConnectionTime, connTimeout, readTimeout, clientType)
         } else {
           new ElasticsearchSenderTransport(finalConfig, None, maxConnectionTime)
         }

--- a/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/SnowplowElasticsearchEmitter.scala
+++ b/4-storage/kinesis-elasticsearch-sink/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/elasticsearch/SnowplowElasticsearchEmitter.scala
@@ -96,8 +96,8 @@ class SnowplowElasticsearchEmitter(
   private val Log = LogFactory.getLog(getClass)
 
   private val newInstance: ElasticsearchSender = (
-    if (elasticsearchClientType == "http") {
-      new ElasticsearchSenderHTTP(configuration, tracker, maxConnectionWaitTimeMs, connTimeout, readTimeout)
+    if ((elasticsearchClientType == "http") || (elasticsearchClientType == "https")) {
+      new ElasticsearchSenderHTTP(configuration, tracker, maxConnectionWaitTimeMs, connTimeout, readTimeout, elasticsearchClientType)
     } else {
       new ElasticsearchSenderTransport(configuration, tracker, maxConnectionWaitTimeMs)
     }


### PR DESCRIPTION
This PR adds HTTPS as a transport option in addition to `http` and `transport`.

Many hosted elasticsearch clusters only support https. Securing the backend requests should be 

This PR:
* Updates elasticsearch 1x, elasticsearch 2x, emitter, and sink classes
* Updates the example hocon config
* Updates the dependencies to include another maven repo for `sbt assembly`


Made in collaboration with @jramos.