### PR TITLE
Fix build of scala-common-enrich

### DIFF
--- a/3-enrich/scala-common-enrich/project/BuildSettings.scala
+++ b/3-enrich/scala-common-enrich/project/BuildSettings.scala
@@ -23,7 +23,7 @@ object BuildSettings {
     organization          :=  "com.snowplowanalytics",
     version               :=  "0.24.1",
     description           :=  "Common functionality for enriching raw Snowplow events",
-    scalaVersion          :=  "2.10.1",
+    scalaVersion          :=  "2.10.4",
     scalacOptions         :=  Seq("-deprecation", "-encoding", "utf8",
                                   "-unchecked", "-feature",
                                   "-target:jvm-1.7"),


### PR DESCRIPTION
Running `sbt compile` in `3-enrich/scala-common-enrich` produces the following error message:

```
snowplow-common-enrich > compile
[info] Compiling 72 Scala sources to /home/fliang/gigster/snowplow/snowplow/3-enrich/scala-common-enrich/target/classes...
[info] 'compiler-interface' not yet compiled for Scala 2.10.1. Compiling...
error: error while loading CharSequence, class file '/usr/lib/jvm/java-8-jdk/jre/lib/rt.jar(java/lang/CharSequence.class)' is broken
(class java.lang.RuntimeException/bad constant pool tag 18 at byte 10)
error: error while loading Comparator, class file '/usr/lib/jvm/java-8-jdk/jre/lib/rt.jar(java/util/Comparator.class)' is broken
(class java.lang.RuntimeException/bad constant pool tag 18 at byte 20)
error: error while loading AnnotatedElement, class file '/usr/lib/jvm/java-8-jdk/jre/lib/rt.jar(java/lang/reflect/AnnotatedElement.class)' is broken
(class java.lang.RuntimeException/bad constant pool tag 18 at byte 76)
error: error while loading Arrays, class file '/usr/lib/jvm/java-8-jdk/jre/lib/rt.jar(java/util/Arrays.class)' is broken
(class java.lang.RuntimeException/bad constant pool tag 18 at byte 765)
/tmp/sbt_2d00b324/xsbt/ExtractAPI.scala:489: error: java.util.Comparator does not take type parameters
        private[this] val sortClasses = new Comparator[Symbol] {
                                            ^
5 errors found
[error] (compile:compile) Error compiling sbt component 'compiler-interface'
[error] Total time: 1 s, completed May 12, 2017 2:57:00 PM
```

According to https://github.com/sbt/sbt/issues/1399, this is fixed by bumping the Scala Version.

After this change, compilation succeeds:
```
snowplow-common-enrich > compile
[info] Updating {file:/home/fliang/gigster/snowplow/snowplow/3-enrich/scala-common-enrich/}snowplow-common-enrich...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] Done updating.
[info] Compiling 72 Scala sources to /home/fliang/gigster/snowplow/snowplow/3-enrich/scala-common-enrich/target/classes...
[info] 'compiler-interface' not yet compiled for Scala 2.10.4. Compiling...
[info]   Compilation completed in 5.884 s
[warn] /home/fliang/gigster/snowplow/snowplow/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/utils/MapTransformer.scala:106: implicit conversion method makeTransformable should be enabled
[warn] by making the implicit value scala.language.implicitConversions visible.
[warn] This can be achieved by adding the import clause 'import scala.language.implicitConversions'
[warn] or by setting the compiler option -language:implicitConversions.
[warn] See the Scala docs for value scala.language.implicitConversions for a discussion
[warn] why the feature should be explicitly enabled.
[warn]   implicit def makeTransformable[T <: AnyRef](obj: T)(implicit m : Manifest[T]) = new TransformableClass[T](obj)
[warn]                ^
[warn] /home/fliang/gigster/snowplow/snowplow/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/Adapter.scala:100: match may not be exhaustive.
[warn] It would fail on the following inputs: JArray(_), JBool(_), JDecimal(_), JDouble(_), JNothing, JNull, JObject(_)
[warn]           v match {
[warn]           ^
[warn] /home/fliang/gigster/snowplow/snowplow/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/UserAgentUtilsEnrichment.scala:116: method isMobileDevice in class OperatingSystem is deprecated: see corresponding Javadoc for more information.
[warn]         deviceIsMobile = os.isMobileDevice).success
[warn]                             ^
[warn] /home/fliang/gigster/snowplow/snowplow/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/utils/MapTransformer.scala:94: method erasure in trait ClassManifestDeprecatedApis is deprecated: Use runtimeClass instead
[warn]     val newInst = m.erasure.newInstance()
[warn]                     ^
[warn] /home/fliang/gigster/snowplow/snowplow/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/utils/MapTransformer.scala:95: method erasure in trait ClassManifestDeprecatedApis is deprecated: Use runtimeClass instead
[warn]     val result = _transform(newInst, sourceMap, transformMap, getSetters(m.erasure))
[warn]                                                                            ^
[warn] /home/fliang/gigster/snowplow/snowplow/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/utils/MapTransformer.scala:116: method erasure in trait ClassManifestDeprecatedApis is deprecated: Use runtimeClass instead
[warn]     private lazy val setters = getSetters(m.erasure)
[warn]                                             ^
[warn] 6 warnings found
[success] Total time: 34 s, completed May 12, 2017 3:00:09 PM
```