### PR TITLE
Adding a replacement macro for the snowplow uuid within a redirect url.

### DIFF
--- a/2-collectors/clojure-collector/java-servlet/project.clj
+++ b/2-collectors/clojure-collector/java-servlet/project.clj
@@ -13,7 +13,7 @@
 ;;;; Copyright: Copyright (c) 2012-2013 Snowplow Analytics Ltd
 ;;;; License:   Apache License Version 2.0
 
-(defproject snowplow/clojure-collector "1.1.0" ;; MUST also bump version in server.xml
+(defproject snowplow/clojure-collector "1.1.0-onespot" ;; MUST also bump version in server.xml
   :license {:name "Apache Version 2.0" 
   :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :description "A SnowPlow event collector written in Clojure. AWS Elastic Beanstalk compatible."

--- a/2-collectors/clojure-collector/java-servlet/src/snowplow/clojure_collector/responses.clj
+++ b/2-collectors/clojure-collector/java-servlet/src/snowplow/clojure_collector/responses.clj
@@ -68,7 +68,7 @@
                     "Content-Type"   "image/gif"
                     "Content-Length"  pixel-length)
      :cookies cookies
-     :body    (ByteArrayInputStream. pixel)})   
+     :body    (ByteArrayInputStream. pixel)})
 
 (defn- send-cookie-200
   "Respond with a 200,
@@ -76,7 +76,12 @@
   [cookies headers]
     {:status  200
      :headers headers
-     :cookies cookies})   
+     :cookies cookies})
+
+(defn- replace-id
+  "Replace placeholder with value"
+  [url id]
+    (clojure.string/replace url "${SP_UUID}" id))
 
 (defn- send-redirect
   "If our params map contains `u`, 302 redirect to that URI,
@@ -100,7 +105,12 @@
         cookies (if (= duration 0)
                   {}
                   {cookie-name (set-cookie id duration domain)})
-        headers {"P3P" p3p-header}]
+        headers {"P3P" p3p-header}
+        {url "u"} params
+        params (if (nil? url)
+                 params
+                 (assoc params "u" (replace-id url id)))
+        ]
     (if (= vendor "r")
       (send-redirect cookies headers params)
       (if pixel

--- a/2-collectors/clojure-collector/java-servlet/test/snowplow/clojure_collector/responses_test.clj
+++ b/2-collectors/clojure-collector/java-servlet/test/snowplow/clojure_collector/responses_test.clj
@@ -19,3 +19,14 @@
 
 ; TODO: add tests along similar lines to:
 ; http://mmcgrana.github.com/2010/07/develop-deploy-clojure-web-applications.html
+(deftest test-uuid-replace
+  (let [cookies {"sp" {:value "123456"}}
+        duration 0
+        domain ""
+        p3pheader ""
+        pixel false
+        vendor "r"
+        params {"u" "http://localhost/?uid=${SP_UUID}"}
+        response (send-cookie-pixel-or-200-or-redirect cookies duration domain p3pheader pixel vendor params)]
+    (is (= 302 (:status response)))
+    (is (= "http://localhost/?uid=123456" (get-in response [:headers "Location"])))))

--- a/2-collectors/clojure-collector/java-servlet/war-resources/.ebextensions/cronjob.config
+++ b/2-collectors/clojure-collector/java-servlet/war-resources/.ebextensions/cronjob.config
@@ -5,7 +5,7 @@ files:
         group: root
         content: |
              MAILTO=""
-             */5 * * * * root /etc/cron.hourly/cron.logrotate.elasticbeanstalk.tomcat8.conf
+             * * * * * root /etc/cron.hourly/cron.logrotate.elasticbeanstalk.tomcat8.conf
 
     "/etc/logrotate.elasticbeanstalk.hourly/logrotate.elasticbeanstalk.tomcat8.conf":
         mode: "000644"
@@ -13,8 +13,8 @@ files:
         group: root
         content: |
             /var/log/tomcat8/* {
-            size 64M
-            hourly
+            maxsize 256M
+            daily
             rotate 2000
             missingok
             compress

--- a/2-collectors/clojure-collector/java-servlet/war-resources/.ebextensions/cronjob.config
+++ b/2-collectors/clojure-collector/java-servlet/war-resources/.ebextensions/cronjob.config
@@ -1,0 +1,29 @@
+files:
+    "/etc/cron.d/onespot-logrotate":
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+             MAILTO=""
+             */10 * * * * root /etc/cron.hourly/cron.logrotate.elasticbeanstalk.tomcat8.conf
+
+    "/etc/logrotate.elasticbeanstalk.hourly/logrotate.elasticbeanstalk.tomcat8.conf":
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            /var/log/tomcat8/* {
+            size 100M
+            rotate 500
+            missingok
+            compress
+            notifempty
+            copytruncate
+            dateext
+            dateformat %s
+            olddir /var/log/tomcat8/rotated
+            }
+
+commands:
+    remove_old_cron:
+        command: "rm -f /etc/cron.d/*.bak"

--- a/2-collectors/clojure-collector/java-servlet/war-resources/.ebextensions/cronjob.config
+++ b/2-collectors/clojure-collector/java-servlet/war-resources/.ebextensions/cronjob.config
@@ -13,7 +13,7 @@ files:
         group: root
         content: |
             /var/log/tomcat8/* {
-            maxsize 256M
+            maxsize 512M
             daily
             rotate 2000
             missingok

--- a/2-collectors/clojure-collector/java-servlet/war-resources/.ebextensions/cronjob.config
+++ b/2-collectors/clojure-collector/java-servlet/war-resources/.ebextensions/cronjob.config
@@ -5,7 +5,7 @@ files:
         group: root
         content: |
              MAILTO=""
-             */10 * * * * root /etc/cron.hourly/cron.logrotate.elasticbeanstalk.tomcat8.conf
+             */5 * * * * root /etc/cron.hourly/cron.logrotate.elasticbeanstalk.tomcat8.conf
 
     "/etc/logrotate.elasticbeanstalk.hourly/logrotate.elasticbeanstalk.tomcat8.conf":
         mode: "000644"
@@ -13,8 +13,9 @@ files:
         group: root
         content: |
             /var/log/tomcat8/* {
-            size 100M
-            rotate 500
+            size 64M
+            hourly
+            rotate 2000
             missingok
             compress
             notifempty

--- a/2-collectors/clojure-collector/java-servlet/war-resources/.ebextensions/cronjob.config
+++ b/2-collectors/clojure-collector/java-servlet/war-resources/.ebextensions/cronjob.config
@@ -1,19 +1,49 @@
 files:
+    "/etc/logrotate.elasticbeanstalk.hourly/logrotate.elasticbeanstalk.tomcat8.conf":
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            /var/log/tomcat8/catalina*
+            /var/log/tomcat8/host*
+            /var/log/tomcat8/localhost.*
+            /var/log/tomcat8/manager*
+            /var/log/tomcat8/tomcat8* {
+            rotate 5
+            missingok
+            compress
+            notifempty
+            copytruncate
+            dateext
+            dateformat %s
+            olddir /var/log/tomcat8/rotated
+            }
+
     "/etc/cron.d/onespot-logrotate":
         mode: "000644"
         owner: root
         group: root
         content: |
              MAILTO=""
-             * * * * * root /etc/cron.hourly/cron.logrotate.elasticbeanstalk.tomcat8.conf
+             * * * * * root /opt/cron.logrotate.onespot.sh
 
-    "/etc/logrotate.elasticbeanstalk.hourly/logrotate.elasticbeanstalk.tomcat8.conf":
+    "/opt/cron.logrotate.onespot.sh":
+        mode: "00744"
+        owner: root
+        group: root
+        content: |
+            #!/bin/sh
+            test -x /usr/sbin/logrotate || exit 0
+            # Running without the -f flag in order to honor size and interval
+            /usr/sbin/logrotate /opt/logrotate.onespot.tomcat8.conf
+
+    "/opt/logrotate.onespot.tomcat8.conf":
         mode: "000644"
         owner: root
         group: root
         content: |
-            /var/log/tomcat8/* {
-            maxsize 512M
+            /var/log/tomcat8/localhost_access* {
+            maxsize 256M
             daily
             rotate 2000
             missingok

--- a/2-collectors/clojure-collector/java-servlet/war-resources/.ebextensions/server.xml
+++ b/2-collectors/clojure-collector/java-servlet/war-resources/.ebextensions/server.xml
@@ -66,7 +66,7 @@
          Define a non-SSL HTTP/1.1 Connector on port 8080
     -->
     <Connector port="8080" maxHttpHeaderSize="65536" protocol="HTTP/1.1"
-               connectionTimeout="20000"
+               connectionTimeout="60000"
                redirectPort="8443"
                URIEncoding="UTF-8"
                enableLookups="true" />


### PR DESCRIPTION
In order to perform ID syncing, we needed the ability to inject the snowplow id within a redirect url.

I decided on a replacement key of ${SP_UUID}. Not sure what kind of documentation needs to change.