### PR TITLE
Scala Stream Collector: use the DefaultAWSCredentialsProviderChain for Kinesis Sink

### DIFF
--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/sinks/KinesisSink.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/sinks/KinesisSink.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.ScheduledExecutorService
 import com.amazonaws.services.kinesis.model.ResourceNotFoundException
 import com.amazonaws.AmazonServiceException
 import com.amazonaws.auth.{
-  EnvironmentVariableCredentialsProvider,
+  DefaultAWSCredentialsProviderChain,
   BasicAWSCredentials,
   ClasspathPropertiesFileCredentialsProvider
 }
@@ -204,7 +204,7 @@ class KinesisSink private (config: CollectorConfig, inputType: InputType.InputTy
     val accessKey = config.awsAccessKey
     val secretKey = config.awsSecretKey
     val client = if (isDefault(accessKey) && isDefault(secretKey)) {
-      new AmazonKinesisClient(new EnvironmentVariableCredentialsProvider())
+      new AmazonKinesisClient(new DefaultAWSCredentialsProviderChain())
     } else if (isDefault(accessKey) || isDefault(secretKey)) {
       throw new RuntimeException("access-key and secret-key must both be set to 'env', or neither")
     } else if (isIam(accessKey) && isIam(secretKey)) {


### PR DESCRIPTION
Bugfix: Using the DefaultAWSCredentialsProviderChain instead of the EnvironmentVariableCredentialsProvider

Example / Docu is pointing to Default Provider:
> If both are set to 'default', the default provider chain is used
> (see http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html)