### PR TITLE
Scala Common Enrich: Add support for IPv6 addresses and 'Forwarded' header

### DIFF
--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/loaders/IpAddressExtractor.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/loaders/IpAddressExtractor.scala
@@ -21,21 +21,21 @@ import scala.annotation.tailrec
  */
 object IpAddressExtractor {
 
-  private val IpExtractionRegex = """^x-forwarded-for: ((?:[0-9]|\.)+).*""".r
+  private val IpExtractionXForwardedForRegex = """^x-forwarded-for: \"?\[?((?:[0-9a-f]|\.|\:+)+).*\]?\"?""".r
 
   /**
    * If a request has been forwarded, extract the original client IP address;
    * otherwise return the standard IP address
    *
-   * @param headers List of headers potentially containing X-FORWARDED-FOR
-   * @param lastIp Fallback IP address if no XI-FORWARDED-FOR header exists
+   * @param headers List of headers potentially containing X-FORWARDED-FOR or FORWARDED
+   * @param lastIp Fallback IP address if no X-FORWARDED-FOR or FORWARDED header exists
    * @return True client IP address
    */
   @tailrec
   def extractIpAddress(headers: List[String], lastIp: String): String = {
     headers match {
       case h :: t => h.toLowerCase match {
-        case IpExtractionRegex(originalIpAddress) => originalIpAddress
+        case IpExtractionXForwardedForRegex(originalIpAddress) => originalIpAddress
         case _ => extractIpAddress(t, lastIp)
       }
       case Nil => lastIp

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/loaders/IpAddressExtractor.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/loaders/IpAddressExtractor.scala
@@ -22,6 +22,7 @@ import scala.annotation.tailrec
 object IpAddressExtractor {
 
   private val IpExtractionXForwardedForRegex = """^x-forwarded-for: \"?\[?((?:[0-9a-f]|\.|\:+)+).*\]?\"?""".r
+  private val IpExtractionForwardedRegex = """^forwarded: for=\"?\[?((?:[0-9a-f]|\.|\:+)+).*\]?\"?""".r
 
   /**
    * If a request has been forwarded, extract the original client IP address;
@@ -36,6 +37,7 @@ object IpAddressExtractor {
     headers match {
       case h :: t => h.toLowerCase match {
         case IpExtractionXForwardedForRegex(originalIpAddress) => originalIpAddress
+        case IpExtractionForwardedRegex(originalIpAddress)     => originalIpAddress
         case _ => extractIpAddress(t, lastIp)
       }
       case Nil => lastIp

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/loaders/IpAddressExtractorSpec.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/loaders/IpAddressExtractorSpec.scala
@@ -24,13 +24,17 @@ class IpAddressExtractorSpec extends Specification with DataTables with Validati
   "extractIpAddress" should {
     "correctly extract an X-FORWARDED-FOR header" in {
 
-      "SPEC NAME"                                           || "HEADERS"                                                                                                | "EXP. RESULT"   |
-      "No headers"                                          !! Nil                                                                                                      ! Default         |
-      "No X-FORWARDED-FOR header"                           !! List("Accept-Charset: utf-8", "Connection: keep-alive")                                                  ! Default         |
-      "Unparseable X-FORWARDED-FOR header"                  !! List("X-Forwarded-For: localhost")                                                                       ! Default         |
-      "Good X-FORWARDED-FOR header"                         !! List("Accept-Charset: utf-8", "X-Forwarded-For: 129.78.138.66, 129.78.64.103", "Connection: keep-alive") ! "129.78.138.66" |
-      "Good incorrectly capitalized X-FORWARDED-FOR header" !! List("Accept-Charset: utf-8", "x-FoRwaRdeD-FOr: 129.78.138.66, 129.78.64.103", "Connection: keep-alive") ! "129.78.138.66" |> {
-
+      "SPEC NAME"                                           || "HEADERS"                                                                                                | "EXP. RESULT"                             |
+      "No headers"                                          !! Nil                                                                                                      ! Default                                   |
+      "No X-FORWARDED-FOR header"                           !! List("Accept-Charset: utf-8", "Connection: keep-alive")                                                  ! Default                                   |
+      "Unparseable X-FORWARDED-FOR header"                  !! List("X-Forwarded-For: localhost")                                                                       ! Default                                   |
+      "Good X-FORWARDED-FOR header"                         !! List("Accept-Charset: utf-8", "X-Forwarded-For: 129.78.138.66, 129.78.64.103", "Connection: keep-alive") ! "129.78.138.66"                           |
+      "Good incorrectly capitalized X-FORWARDED-FOR header" !! List("Accept-Charset: utf-8", "x-FoRwaRdeD-FOr: 129.78.138.66, 129.78.64.103", "Connection: keep-alive") ! "129.78.138.66"                           |
+      "IPv6 address in X-FORWARDED-FOR header"              !! List("X-Forwarded-For: 2001:0db8:85a3:0000:0000:8a2e:0370:7334")                                         ! "2001:0db8:85a3:0000:0000:8a2e:0370:7334" |
+      "IPv6 quoted address in X-FORWARDED-FOR header"       !! List("X-Forwarded-For: \"[2001:0db8:85a3:0000:0000:8a2e:0370:7334]\"")                                   ! "2001:0db8:85a3:0000:0000:8a2e:0370:7334" |
+      "IPv4 address in Forwarded header"                    !! List("Forwarded: for=129.78.138.66, 129.78.64.103")                                                      ! "129.78.138.66"                           |
+      "IPv6 incorrectly quoted address in Forwarded header" !! List("Forwarded: for=2001:0db8:85a3:0000:0000:8a2e:0370:7334, for=129.78.138.56")                        ! "2001:0db8:85a3:0000:0000:8a2e:0370:7334" |
+      "IPv6 quoted correctly in Forwarded header"           !! List("Forwarded: for=\"[2001:0db8:85a3:0000:0000:8a2e:0370:7334]\", \"129.78.128.66\"")                  ! "2001:0db8:85a3:0000:0000:8a2e:0370:7334" |> {
         (_, headers, expected) => {
           IpAddressExtractor.extractIpAddress(headers, Default) must_== expected
         }


### PR DESCRIPTION
This pull request addresses two issues:

1) #3474 Adds support for IPv6 addresses by modifying the IpExtraction regular expressions to include the ability to match both IPv6 and IPv4 (including optional quoting)
2) #3475 Adds support for matching IPv4 and IPv6 addresses that are present in the `Forwarded` header (including required quoting for IPv6).

This includes a few additional test cases to test for IPv6 dummy values and possibly quoting options.