### PR TITLE
Scala Stream Collector: add URL redirect replacement macro

### DIFF
--- a/2-collectors/scala-stream-collector/examples/config.hocon.sample
+++ b/2-collectors/scala-stream-collector/examples/config.hocon.sample
@@ -54,6 +54,15 @@ collector {
     fallbackNetworkUserId = "00000000-0000-4000-A000-000000000000"
   }
 
+  # When enabled, the redirect url passed via the `u` query parameter is scanned for a placeholder token.
+  # All instances of that token are replaced withe the network ID. If the placeholder isn't specified, the
+  # default value is `${SP_UUID}`.
+  redirectMacro {
+    enabled = false
+    # You can provide a custom placeholder token (defaults to ${SP_UUID})
+    placeholder = "[TOKEN]"
+  }
+
   streams {
     # Events which have successfully been collected will be stored in the good stream/topic
     good = {{good}}

--- a/2-collectors/scala-stream-collector/examples/config.hocon.sample
+++ b/2-collectors/scala-stream-collector/examples/config.hocon.sample
@@ -56,10 +56,10 @@ collector {
 
   # When enabled, the redirect url passed via the `u` query parameter is scanned for a placeholder token.
   # All instances of that token are replaced withe the network ID. If the placeholder isn't specified, the
-  # default value is `${SP_UUID}`.
+  # default value is `${SP_NUID}`.
   redirectMacro {
     enabled = false
-    # You can provide a custom placeholder token (defaults to ${SP_UUID})
+    # You can provide a custom placeholder token (defaults to ${SP_NUID})
     placeholder = "[TOKEN]"
   }
 

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
@@ -235,7 +235,9 @@ class CollectorService(
     queryParams: Map[String, String]
   ): (HttpResponse, List[Array[Byte]]) =
     queryParams.get("u") match {
-      case Some(target) => (HttpResponse(StatusCodes.Found).withHeaders(`Location`(target)), Nil)
+      case Some(target) =>
+        val replacedTarget = if (event.isSetNetworkUserId) target.replaceAllLiterally("${SP_UUID}", event.networkUserId) else target
+        (HttpResponse(StatusCodes.Found).withHeaders(`Location`(replacedTarget)), Nil)
       case None =>
         val badRow = createBadRow(event, "Redirect failed due to lack of u parameter")
         (HttpResponse(StatusCodes.BadRequest),

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
@@ -236,7 +236,9 @@ class CollectorService(
   ): (HttpResponse, List[Array[Byte]]) =
     queryParams.get("u") match {
       case Some(target) =>
-        val replacedTarget = if (event.isSetNetworkUserId) target.replaceAllLiterally("${SP_UUID}", event.networkUserId) else target
+        val canReplace = config.redirectMacro.enabled && event.isSetNetworkUserId
+        val token = config.redirectMacro.placeholder.getOrElse("${SP_UUID}")
+        val replacedTarget = if (canReplace) target.replaceAllLiterally(token, event.networkUserId) else target
         (HttpResponse(StatusCodes.Found).withHeaders(`Location`(replacedTarget)), Nil)
       case None =>
         val badRow = createBadRow(event, "Redirect failed due to lack of u parameter")

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
@@ -237,7 +237,7 @@ class CollectorService(
     queryParams.get("u") match {
       case Some(target) =>
         val canReplace = config.redirectMacro.enabled && event.isSetNetworkUserId
-        val token = config.redirectMacro.placeholder.getOrElse("${SP_UUID}")
+        val token = config.redirectMacro.placeholder.getOrElse("${SP_NUID}")
         val replacedTarget = if (canReplace) target.replaceAllLiterally(token, event.networkUserId) else target
         (HttpResponse(StatusCodes.Found).withHeaders(`Location`(replacedTarget)), Nil)
       case None =>

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
@@ -56,6 +56,10 @@ package model {
     name: String,
     fallbackNetworkUserId: String
   )
+  final case class RedirectMacroConfig(
+    enabled: Boolean,
+    placeholder: Option[String]
+  )
   final case class P3PConfig(policyRef: String, CP: String)
   final case class AWSConfig(accessKey: String, secretKey: String) {
     val provider = ((accessKey, secretKey) match {
@@ -109,6 +113,8 @@ package model {
     p3p: P3PConfig,
     cookie: CookieConfig,
     cookieBounce: CookieBounceConfig,
+    redirectMacro: RedirectMacroConfig,
+    sink: String,
     streams: StreamsConfig
   ) {
     val cookieConfig = if (cookie.enabled) Some(cookie) else None

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
@@ -114,7 +114,6 @@ package model {
     cookie: CookieConfig,
     cookieBounce: CookieBounceConfig,
     redirectMacro: RedirectMacroConfig,
-    sink: String,
     streams: StreamsConfig
   ) {
     val cookieConfig = if (cookie.enabled) Some(cookie) else None

--- a/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
+++ b/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
@@ -291,5 +291,13 @@ class CollectorServiceSpec extends Specification {
           `Access-Control-Allow-Origin`(HttpOriginRange.`*`)
       }
     }
+
+    "cookieRedirectMacro" in {
+      "the collector should support a cookie replacement macro on redirect" in {
+        event.networkUserId = "1234"
+        val (res, Nil) = service.buildRedirectHttpResponse(event, "k", Map("u" -> "http://localhost/?uid=${SP_UUID}"))
+        res shouldEqual HttpResponse(302).withHeaders(`Location`("http://localhost/?uid=1234"))
+      }
+    }
   }
 }

--- a/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
+++ b/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
@@ -205,8 +205,8 @@ class CollectorServiceSpec extends Specification {
       }*/
       "the redirect url should not support a cookie replacement macro on redirect if not enabled" in {
         event.networkUserId = "1234"
-        val (res, Nil) = service.buildRedirectHttpResponse(event, "k", Map("u" -> "http://localhost/?uid=${SP_UUID}"))
-        res shouldEqual HttpResponse(302).withHeaders(`Location`("http://localhost/?uid=${SP_UUID}"))
+        val (res, Nil) = service.buildRedirectHttpResponse(event, "k", Map("u" -> "http://localhost/?uid=${SP_NUID}"))
+        res shouldEqual HttpResponse(302).withHeaders(`Location`("http://localhost/?uid=${SP_NUID}"))
       }
       "the redirect url should support a cookie replacement macro on redirect if enabled" in {
         val redirectService = new CollectorService(
@@ -214,7 +214,7 @@ class CollectorServiceSpec extends Specification {
           CollectorSinks(new TestSink, new TestSink)
         )
         event.networkUserId = "1234"
-        val (res, Nil) = redirectService.buildRedirectHttpResponse(event, "k", Map("u" -> "http://localhost/?uid=${SP_UUID}"))
+        val (res, Nil) = redirectService.buildRedirectHttpResponse(event, "k", Map("u" -> "http://localhost/?uid=${SP_NUID}"))
         res shouldEqual HttpResponse(302).withHeaders(`Location`("http://localhost/?uid=1234"))
       }
       "the redirect url should allow for custom token placeholders" in {

--- a/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/TestUtils.scala
+++ b/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/TestUtils.scala
@@ -25,6 +25,8 @@ object TestUtils {
     p3p = P3PConfig("/w3c/p3p.xml", "NOI DSP COR NID PSA OUR IND COM NAV STA"),
     cookie = CookieConfig(true, "sp", 365.days, None),
     cookieBounce = CookieBounceConfig(false, "bounce", "new-nuid"),
+    redirectMacro = RedirectMacroConfig(false, None),
+    sink = "stdout",
     streams = StreamsConfig(
       good = "good",
       bad = "bad",

--- a/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/TestUtils.scala
+++ b/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/TestUtils.scala
@@ -26,7 +26,6 @@ object TestUtils {
     cookie = CookieConfig(true, "sp", 365.days, None),
     cookieBounce = CookieBounceConfig(false, "bounce", "new-nuid"),
     redirectMacro = RedirectMacroConfig(false, None),
-    sink = "stdout",
     streams = StreamsConfig(
       good = "good",
       bad = "bad",


### PR DESCRIPTION
Updates the Scala Stream Collector to look for a replacement macro in the redirect url in order to support cookie syncing with third parties.

Currently, the macro placeholder is hard coded to ${SP_UUID}. I image this feature could be enabled through the config and the placeholder parameterized, if this is desirable.

@alexanderdean 