### PR TITLE
Scala Stream Collector: allow use of the originating scheme during cookie bounce

### DIFF
--- a/2-collectors/scala-stream-collector/examples/config.hocon.sample
+++ b/2-collectors/scala-stream-collector/examples/config.hocon.sample
@@ -55,7 +55,7 @@ collector {
     # Optionally, specify the name of the  header containing the originating protocol for use in the bounce redirect
     # location. Use this if behind a load balancer that performs SSL termination. The value of this header must
     # be http or https. Example, if behind an AWS Classic ELB.
-    forwardedProtocolHeader: "X-Forwarded-Proto"
+    forwardedProtocolHeader = "X-Forwarded-Proto"
   }
 
   streams {

--- a/2-collectors/scala-stream-collector/examples/config.hocon.sample
+++ b/2-collectors/scala-stream-collector/examples/config.hocon.sample
@@ -52,6 +52,10 @@ collector {
     name = "n3pc"
     # Network user id to fallback to when third-party cookies are blocked.
     fallbackNetworkUserId = "00000000-0000-4000-A000-000000000000"
+    # Optionally, specify the name of the  header containing the originating protocol for use in the bounce redirect
+    # location. Use this if behind a load balancer that performs SSL termination. The value of this header must
+    # be http or https. Example, if behind an AWS Classic ELB.
+    forwardedProtocolHeader: "X-Forwarded-Proto"
   }
 
   streams {

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
@@ -52,10 +52,10 @@ package model {
     domain: Option[String]
   )
   final case class CookieBounceConfig(
-   enabled: Boolean,
-   name: String,
-   fallbackNetworkUserId: String,
-   forwardedProtocolHeader: Option[String]
+    enabled: Boolean,
+    name: String,
+    fallbackNetworkUserId: String,
+    forwardedProtocolHeader: Option[String]
   )
   final case class P3PConfig(policyRef: String, CP: String)
   final case class AWSConfig(accessKey: String, secretKey: String) {

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
@@ -52,9 +52,10 @@ package model {
     domain: Option[String]
   )
   final case class CookieBounceConfig(
-    enabled: Boolean,
-    name: String,
-    fallbackNetworkUserId: String
+   enabled: Boolean,
+   name: String,
+   fallbackNetworkUserId: String,
+   forwardedProtocolHeader: Option[String]
   )
   final case class P3PConfig(policyRef: String, CP: String)
   final case class AWSConfig(accessKey: String, secretKey: String) {

--- a/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/TestUtils.scala
+++ b/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/TestUtils.scala
@@ -24,7 +24,7 @@ object TestUtils {
     port = 8080,
     p3p = P3PConfig("/w3c/p3p.xml", "NOI DSP COR NID PSA OUR IND COM NAV STA"),
     cookie = CookieConfig(true, "sp", 365.days, None),
-    cookieBounce = CookieBounceConfig(false, "bounce", "new-nuid"),
+    cookieBounce = CookieBounceConfig(false, "bounce", "new-nuid", None),
     streams = StreamsConfig(
       good = "good",
       bad = "bad",


### PR DESCRIPTION
Commit adds a new configuration parameter (`forwardedProtocolHeader`) in the
cookie bounce feature. This parameter specifies the name of an http header
that contains the originating protocol if deployed behind a load balancer.

This is useful if SSL termination happens at the load balancer in order to
maintain the security model of you web page.

Fixes #3505 