### PR TITLE
Scala Stream Collector: replace Location header with RawHeader to preserve double encoding

### DIFF
--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
@@ -249,7 +249,7 @@ class CollectorService(
         val replacedTarget =
           if (canReplace) target.replaceAllLiterally(token, event.networkUserId)
           else target
-        (HttpResponse(StatusCodes.Found).withHeaders(`Location`(replacedTarget)), Nil)
+        (HttpResponse(StatusCodes.Found).withHeaders(`RawHeader`("Location", replacedTarget)), Nil)
       case None =>
         val badRow = createBadRow(event, "Redirect failed due to lack of u parameter")
         (HttpResponse(StatusCodes.BadRequest),

--- a/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
+++ b/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
@@ -156,7 +156,7 @@ class CollectorServiceSpec extends Specification {
         val (res, Nil) = service.buildHttpResponse(
           event, "k", Map("u" -> "12"), hs, true, true, false, sinkConf, redirConf)
         res shouldEqual HttpResponse(302)
-          .withHeaders(`Location`("12") :: hs)
+          .withHeaders(`RawHeader`("Location", "12") :: hs)
       }
       "send back a gif if pixelExpected is true" in {
         val (res, Nil) = service.buildHttpResponse(
@@ -198,7 +198,7 @@ class CollectorServiceSpec extends Specification {
       val redirConf = TestUtils.testConf.redirectMacro
       "give back a 302 if redirecting and there is a u query param" in {
         val (res, Nil) = service.buildRedirectHttpResponse(event, "k", Map("u" -> "12"), redirConf)
-        res shouldEqual HttpResponse(302).withHeaders(`Location`("12"))
+        res shouldEqual HttpResponse(302).withHeaders(`RawHeader`("Location", "12"))
       }
       /* scalaz incompat
       "give back a 400 if redirecting and there are no u query params" in {
@@ -210,20 +210,24 @@ class CollectorServiceSpec extends Specification {
         val (res, Nil) = service.buildRedirectHttpResponse(
           event, "k", Map("u" -> "http://localhost/?uid=${SP_NUID}"), redirConf)
         res shouldEqual HttpResponse(302)
-          .withHeaders(`Location`("http://localhost/?uid=${SP_NUID}"))
+          .withHeaders(`RawHeader`("Location", "http://localhost/?uid=${SP_NUID}"))
       }
       "the redirect url should support a cookie replacement macro on redirect if enabled" in {
         event.networkUserId = "1234"
         val (res, Nil) = service.buildRedirectHttpResponse(
           event, "k", Map("u" -> "http://localhost/?uid=${SP_NUID}"), redirConf.copy(enabled = true))
-        res shouldEqual HttpResponse(302).withHeaders(`Location`("http://localhost/?uid=1234"))
+        res shouldEqual HttpResponse(302).withHeaders(`RawHeader`("Location", "http://localhost/?uid=1234"))
       }
       "the redirect url should allow for custom token placeholders" in {
         event.networkUserId = "1234"
         val (res, Nil) = service.buildRedirectHttpResponse(
           event, "k", Map("u" -> "http://localhost/?uid=[TOKEN]"),
           redirConf.copy(enabled = true, Some("[TOKEN]")))
-        res shouldEqual HttpResponse(302).withHeaders(`Location`("http://localhost/?uid=1234"))
+        res shouldEqual HttpResponse(302).withHeaders(`RawHeader`("Location", "http://localhost/?uid=1234"))
+      }
+      "the redirect url should allow for double encoding for return redirects" in {
+        val (res, Nil) = service.buildRedirectHttpResponse(event, "k", Map("u" -> "a%3Db"), redirConf)
+        res shouldEqual HttpResponse(302).withHeaders(`RawHeader`("Location", "a%3Db"))
       }
     }
 


### PR DESCRIPTION
Making this change in order preserver double encoding URLs for use in
redirect chains. This also matches the behavior of the Clojure Collector.