### PR TITLE
[scala-stream-collector] Expose metrics over jmx

### DIFF
--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRoute.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRoute.scala
@@ -45,7 +45,7 @@ trait CollectorRoute {
             post {
               extractContentType { ct =>
                 entity(as[String]) { body =>
-                  val (r,l) = collectorService.cookie(qs, Some(body),
+                  val (r, _) = collectorService.cookie(qs, Some(body),
                       path, cookie, userAgent, refererURI, host, ip, request, false, Some(ct))
 
                   incrementRequests(r._1)
@@ -54,7 +54,7 @@ trait CollectorRoute {
               }
             } ~
             get {
-              val (r,l) = collectorService.cookie(
+              val (r, _) = collectorService.cookie(
                 qs, None, path, cookie, userAgent, refererURI, host, ip, request, true)
 
               incrementRequests(r._1)

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRoute.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRoute.scala
@@ -24,8 +24,6 @@ import monitoring.BeanRegistry
 trait CollectorRoute {
   def collectorService: Service
 
-  private val successfulStatuses = List(StatusCodes.OK, StatusCodes.Found)
-
   private val headers = optionalHeaderValueByName("User-Agent") &
     optionalHeaderValueByName("Referer") &
     optionalHeaderValueByName("Raw-Request-URI")
@@ -120,6 +118,7 @@ trait CollectorRoute {
     }
   }
 
+  private val successfulStatuses = List(StatusCodes.OK, StatusCodes.Found)
   private def incrementRequests(status: StatusCode) : Unit = {
     if (successfulStatuses.contains(status)) {
       BeanRegistry.collectorBean.incrementSuccessfulRequests()

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRoute.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRoute.scala
@@ -18,7 +18,8 @@ import akka.http.scaladsl.model.{ContentType, HttpResponse, StatusCode, StatusCo
 import akka.http.scaladsl.model.headers.HttpCookiePair
 import akka.http.scaladsl.server.{Directive1, Route}
 import akka.http.scaladsl.server.Directives._
-import com.snowplowanalytics.snowplow.collectors.scalastream.monitoring.BeanRegistry
+
+import monitoring.BeanRegistry
 
 trait CollectorRoute {
   def collectorService: Service

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/monitoring/JMX.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/monitoring/JMX.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2018 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0, and
+ * you may not use this file except in compliance with the Apache License
+ * Version 2.0.  You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Apache License Version 2.0 is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the Apache License Version 2.0 for the specific language
+ * governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.collectors.scalastream
+package monitoring
+
+import java.lang.management.ManagementFactory
+import javax.management.{MBeanServer, ObjectName}
+import scala.beans.BeanProperty
+
+trait SnowplowMXBean {
+  def getLatest() : Long
+  def getRequests() : Int
+  def getSuccessfulRequests() : Int
+  def getFailedRequests() : Int
+
+  def incrementSuccessfulRequests() : Unit
+  def incrementFailedRequests() : Unit
+}
+
+class SnowplowScalaCollectorMetrics extends SnowplowMXBean {
+  @BeanProperty
+  var latest = now()
+
+  @BeanProperty
+  var requests = 0
+
+  @BeanProperty
+  var successfulRequests = 0
+
+  @BeanProperty
+  var failedRequests = 0
+
+  override def incrementSuccessfulRequests = {
+    successfulRequests += 1
+
+    incrementRequests()
+  }
+
+  override def incrementFailedRequests = {
+    failedRequests += 1
+
+    incrementRequests()
+  }
+
+  def incrementRequests() = {
+    requests += 1
+    latest = now()
+  }
+
+  def now() : Long = {
+    System.currentTimeMillis() / 1000L
+  }
+}
+
+object BeanRegistry {
+  val collectorBean = new SnowplowScalaCollectorMetrics
+
+  val mbs: MBeanServer = ManagementFactory.getPlatformMBeanServer
+  val mBeanName: ObjectName = new ObjectName(s"${this.getClass.getPackage.getName}:type=ScalaCollector")
+
+  mbs.registerMBean(collectorBean, mBeanName)
+}


### PR DESCRIPTION
The ability to determine whether or not the stream collector is doing much without interrogating/ pattern matching logs is useful for scaling events and debugging.

This PR introduces a custom mbean which starts to expose useful information. Hooking it into `jmxtrans` with the following config (for example):

```xml
    <query objectName="com.snowplowanalytics.snowplow.collectors.scalastream.monitoring:type=ScalaCollector" attribute="Latest"
           resultAlias="scalastream.Latest" />
    <query objectName="com.snowplowanalytics.snowplow.collectors.scalastream.monitoring:type=ScalaCollector" attribute="Requests"
           resultAlias="scalastream.Requests" />
    <query objectName="com.snowplowanalytics.snowplow.collectors.scalastream.monitoring:type=ScalaCollector" attribute="SuccessfulRequests"
           resultAlias="scalastream.SuccessfulRequests"/>
    <query objectName="com.snowplowanalytics.snowplow.collectors.scalastream.monitoring:type=ScalaCollector" attribute="FailedRequests"
           resultAlias="scalastream.FailedRequests"/>
```

Would allow a developer to interrogate metrics like:

```
scalastream.Latest 1519302379 1519302389
scalastream.Requests 1 1519302389
scalastream.SuccessfulRequests 0 1519302389
scalastream.FailedRequests 1 1519302389
```