### PR TITLE
Adding Marketo adapter to enrichment

### DIFF
--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/AdapterRegistry.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/AdapterRegistry.scala
@@ -53,6 +53,7 @@ object AdapterRegistry {
     val StatusGator     = "com.statusgator"
     val Unbounce        = "com.unbounce"
     val UrbanAirship    = "com.urbanairship.connect"
+    val Marketo         = "com.marketo"
   }
 
   /**
@@ -87,6 +88,7 @@ object AdapterRegistry {
       case (Vendor.StatusGator, "v1")           => StatusGatorAdapter.toRawEvents(payload)
       case (Vendor.Unbounce, "v1")              => UnbounceAdapter.toRawEvents(payload)
       case (Vendor.UrbanAirship, "v1")          => UrbanAirshipAdapter.toRawEvents(payload)
+      case (Vendor.Marketo, "v1")               => MarketoAdapter.toRawEvents(payload)
       case _ =>
         s"Payload with vendor ${payload.api.vendor} and version ${payload.api.version} not supported by this version of Scala Common Enrich".failNel
     }

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/MarketoAdapter.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/MarketoAdapter.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2017 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics
+package snowplow
+package enrich
+package common
+package adapters
+package registry
+
+// Java
+import com.fasterxml.jackson.core.JsonParseException
+
+// Scalaz
+import scalaz.Scalaz._
+
+// json4s
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+
+// Iglu
+import com.snowplowanalytics.iglu.client.{Resolver, SchemaKey}
+
+// Joda Time
+import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
+
+// This project
+import com.snowplowanalytics.snowplow.enrich.common.loaders.CollectorPayload
+import com.snowplowanalytics.snowplow.enrich.common.utils.{JsonUtils => JU}
+
+/**
+ * Transforms a collector payload which conforms to
+ * a known version of the Mailchimp Tracking webhook
+ * into raw events.
+ */
+object MarketoAdapter extends Adapter {
+
+  // Vendor name for Failure Message
+  private val VendorName = "Marketo"
+
+  // Expected content type for a request body
+  private val ContentType = "application/json"
+
+  // Tracker version for an Mailchimp Tracking webhook
+  private val TrackerVersion = "com.marketo-v1"
+
+  // Schemas for reverse-engineering a Snowplow unstructured event
+  private val EventSchemaMap = Map (
+    "event"   -> SchemaKey("com.marketo", "event", "jsonschema", "1-0-0").toSchemaUri 
+  )
+
+  // Datetime format used by Marketo
+  private val MarketoDateTimeFormat = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").withZone(DateTimeZone.UTC)
+
+  private def payloadBodyToEvent(json: String, payload: CollectorPayload): Validated[RawEvent] = {
+
+    try {
+      val parsed = parse(json)
+
+      val parsed_converted = parsed transformField {
+        case ("acquisition_date", JString(value))         => ("acquisition_date", JString(JU.toJsonSchemaDateTime(value, MarketoDateTimeFormat)))
+        case ("created_at", JString(value))               => ("created_at", JString(JU.toJsonSchemaDateTime(value, MarketoDateTimeFormat)))
+        case ("email_suspended_at", JString(value))       => ("email_suspended_at", JString(JU.toJsonSchemaDateTime(value, MarketoDateTimeFormat)))
+        case ("last_referred_enrollment", JString(value)) => ("last_referred_enrollment", JString(JU.toJsonSchemaDateTime(value, MarketoDateTimeFormat)))
+        case ("last_referred_visit", JString(value))      => ("last_referred_visit", JString(JU.toJsonSchemaDateTime(value, MarketoDateTimeFormat)))
+        case ("updated_at", JString(value))               => ("updated_at", JString(JU.toJsonSchemaDateTime(value, MarketoDateTimeFormat)))
+        case ("datetime", JString(value))                 => ("datetime", JString(JU.toJsonSchemaDateTime(value, MarketoDateTimeFormat)))
+    }
+
+      val eventType = Some("event")
+
+      lookupSchema(eventType, VendorName, EventSchemaMap) map {
+        schema => RawEvent(
+            api = payload.api,
+            parameters = toUnstructEventParams(
+              TrackerVersion,
+              toMap(payload.querystring),
+              schema,
+              parsed_converted,
+              "srv"
+            ),
+            contentType = payload.contentType,
+            source = payload.source,
+            context = payload.context
+          )
+      }
+
+    } catch {
+      case e: JsonParseException => {
+        val exception = JU.stripInstanceEtc(e.toString).orNull
+        s"$VendorName event failed to parse into JSON: [$exception]".failNel
+      }
+    }
+  }
+
+  /**
+   * Converts a CollectorPayload instance into raw events.
+   * Marketo event contains no "type" field and since there's only 1 schema the function lookupschema takes the eventType parameter as "event".
+   * We expect the type parameter to match the supported events, else
+   * we have an unsupported event type.
+   *
+   * @param payload The CollectorPayload containing one or more
+   *        raw events as collected by a Snowplow collector
+   * @param resolver (implicit) The Iglu resolver used for
+   *        schema lookup and validation. Not used
+   * @return a Validation boxing either a NEL of RawEvents on
+   *         Success, or a NEL of Failure Strings
+   */
+  def toRawEvents(payload: CollectorPayload)(implicit resolver: Resolver): ValidatedRawEvents =
+    (payload.body, payload.contentType) match {
+      case (None, _) => s"Request body is empty: no ${VendorName} event to process".failNel
+      case (Some(body), _) => {
+        val event = payloadBodyToEvent(body, payload)
+        rawEventsListProcessor(List(event))
+      }
+    }
+}

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/MarketoAdapterSpec.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/MarketoAdapterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2014 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2018 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -28,67 +28,60 @@ import org.json4s.jackson.JsonMethods._
 import org.json4s.scalaz.JsonScalaz._
 
 // Snowplow
-import loaders.{
-  CollectorApi,
-  CollectorSource,
-  CollectorContext,
-  CollectorPayload
-}
+import loaders.{CollectorApi, CollectorContext, CollectorPayload, CollectorSource}
 import utils.ConversionUtils
 import SpecHelpers._
 
 // Specs2
-import org.specs2.{Specification, ScalaCheck}
+import org.specs2.{ScalaCheck, Specification}
 import org.specs2.matcher.DataTables
 import org.specs2.scalaz.ValidationMatchers
 
-class MarketoAdapterSpec extends Specification with DataTables with ValidationMatchers with ScalaCheck { def is = s2"""
+class MarketoAdapterSpec extends Specification with DataTables with ValidationMatchers with ScalaCheck {
+  def is = s2"""
   This is a specification to test the MarketoAdapter functionality
   toRawEvents must return a success for a valid "event" type payload body being passed                $e1
   toRawEvents must return a Failure Nel if a body is not specified in the payload                     $e3
   """
-  //  toRawEvents must return a Nel Success for a supported event type                                    $e2
 
   implicit val resolver = SpecHelpers.IgluResolver
 
   object Shared {
-    val api = CollectorApi("com.marketo", "v1")
+    val api       = CollectorApi("com.marketo", "v1")
     val cljSource = CollectorSource("clj-tomcat", "UTF-8", None)
-    val context = CollectorContext(DateTime.parse("2018-01-01T00:00:00.000+00:00").some, "37.157.33.123".some, None, None, Nil, None)
+    val context = CollectorContext(DateTime.parse("2018-01-01T00:00:00.000+00:00").some,
+                                   "37.157.33.123".some,
+                                   None,
+                                   None,
+                                   Nil,
+                                   None)
   }
 
   val ContentType = "application/json"
 
   def e1 = {
-    val bodyStr = """{"campaign": {"id": 160, "name": "avengers assemble"}, "lead": {"acquisition_date": "2010-11-11 11:11:11", "black_listed": false, "first_name": "the hulk", "updated_at": ""}, "company": {"name": "iron man", "notes": "the something dog leapt over the lazy fox"}, "campaign": {"id": 987, "name": "triggered event"}, "datetime": "2018-03-07 14:28:16"}"""
+    val bodyStr =
+      """{"campaign": {"id": 160, "name": "avengers assemble"}, "lead": {"acquisition_date": "2010-11-11 11:11:11", "black_listed": false, "first_name": "the hulk", "updated_at": ""}, "company": {"name": "iron man", "notes": "the something dog leapt over the lazy fox"}, "campaign": {"id": 987, "name": "triggered event"}, "datetime": "2018-03-07 14:28:16"}"""
     val payload = CollectorPayload(Shared.api, Nil, ContentType.some, bodyStr.some, Shared.cljSource, Shared.context)
     val expected = NonEmptyList(
-        RawEvent(
+      RawEvent(
         Shared.api,
         Map(
-          "tv" -> "com.marketo-v1",
-          "e" -> "ue",
-          "p" -> "srv",
-          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.marketo/event/jsonschema/1-0-0","data":{"campaign":{"id":160,"name":"avengers assemble"},"lead":{"acquisition_date":"2010-11-11T11:11:11.000Z","black_listed":false,"first_name":"the hulk","updated_at":""},"company":{"name":"iron man","notes":"the something dog leapt over the lazy fox"},"campaign":{"id":987,"name":"triggered event"},"datetime":"2018-03-07T14:28:16.000Z"}}}"""),
+          "tv"    -> "com.marketo-v1",
+          "e"     -> "ue",
+          "p"     -> "srv",
+          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.marketo/event/jsonschema/1-0-0","data":{"campaign":{"id":160,"name":"avengers assemble"},"lead":{"acquisition_date":"2010-11-11T11:11:11.000Z","black_listed":false,"first_name":"the hulk","updated_at":""},"company":{"name":"iron man","notes":"the something dog leapt over the lazy fox"},"campaign":{"id":987,"name":"triggered event"},"datetime":"2018-03-07T14:28:16.000Z"}}}"""
+        ),
         ContentType.some,
         Shared.cljSource,
-        Shared.context))
+        Shared.context
+      ))
     MarketoAdapter.toRawEvents(payload) must beSuccessful(expected)
   }
 
-  /*def e2 =
-    "SPEC NAME"                 || "SCHEMA TYPE"    | "EXPECTED SCHEMA"                                 |
-    "Valid, type event"         !! "event"          ! "iglu:com.marketo/event/jsonschema/1-0-0"         |> {
-      (_, schema, expected) =>
-        val body = "{\"type\":\"" + schema + "\"}"
-        val payload = CollectorPayload(Shared.api, Nil, ContentType.some, body.some, Shared.cljSource, Shared.context)
-        val expectedJson = "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"" + expected + "\",\"data\":{}}}"
-        val actual = MarketoAdapter.toRawEvents(payload)
-        actual must beSuccessful(NonEmptyList(RawEvent(Shared.api, Map("tv" -> "com.marketo-v1", "e" -> "ue", "p" -> "srv", "ue_pr" -> expectedJson), ContentType.some, Shared.cljSource, Shared.context)))
-  }*/
-
-  def e3 = {  
+  def e3 = {
     val payload = CollectorPayload(Shared.api, Nil, ContentType.some, None, Shared.cljSource, Shared.context)
-    MarketoAdapter.toRawEvents(payload) must beFailing(NonEmptyList("Request body is empty: no Marketo event to process"))
+    MarketoAdapter.toRawEvents(payload) must beFailing(
+      NonEmptyList("Request body is empty: no Marketo event to process"))
   }
 }

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/MarketoAdapterSpec.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/MarketoAdapterSpec.scala
@@ -41,7 +41,7 @@ class MarketoAdapterSpec extends Specification with DataTables with ValidationMa
   def is = s2"""
   This is a specification to test the MarketoAdapter functionality
   toRawEvents must return a success for a valid "event" type payload body being passed                $e1
-  toRawEvents must return a Failure Nel if a body is not specified in the payload                     $e3
+  toRawEvents must return a Failure Nel if the payload body is empty                                  $e2
   """
 
   implicit val resolver = SpecHelpers.IgluResolver
@@ -61,7 +61,7 @@ class MarketoAdapterSpec extends Specification with DataTables with ValidationMa
 
   def e1 = {
     val bodyStr =
-      """{"campaign": {"id": 160, "name": "avengers assemble"}, "lead": {"acquisition_date": "2010-11-11 11:11:11", "black_listed": false, "first_name": "the hulk", "updated_at": ""}, "company": {"name": "iron man", "notes": "the something dog leapt over the lazy fox"}, "campaign": {"id": 987, "name": "triggered event"}, "datetime": "2018-03-07 14:28:16"}"""
+      """{"name": "webhook for A", "step": 6, "campaign": {"id": 160, "name": "avengers assemble"}, "lead": {"acquisition_date": "2010-11-11 11:11:11", "black_listed": false, "first_name": "the hulk", "updated_at": "", "created_at": "2018-06-16 11:23:58"}, "company": {"name": "iron man", "notes": "the something dog leapt over the lazy fox"}, "campaign": {"id": 987, "name": "triggered event"}, "datetime": "2018-03-07 14:28:16"}"""
     val payload = CollectorPayload(Shared.api, Nil, ContentType.some, bodyStr.some, Shared.cljSource, Shared.context)
     val expected = NonEmptyList(
       RawEvent(
@@ -70,7 +70,7 @@ class MarketoAdapterSpec extends Specification with DataTables with ValidationMa
           "tv"    -> "com.marketo-v1",
           "e"     -> "ue",
           "p"     -> "srv",
-          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.marketo/event/jsonschema/1-0-0","data":{"campaign":{"id":160,"name":"avengers assemble"},"lead":{"acquisition_date":"2010-11-11T11:11:11.000Z","black_listed":false,"first_name":"the hulk","updated_at":""},"company":{"name":"iron man","notes":"the something dog leapt over the lazy fox"},"campaign":{"id":987,"name":"triggered event"},"datetime":"2018-03-07T14:28:16.000Z"}}}"""
+          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.marketo/event/jsonschema/1-0-0","data":{"name":"webhook for A","step":6,"campaign":{"id":160,"name":"avengers assemble"},"lead":{"acquisition_date":"2010-11-11T11:11:11.000Z","black_listed":false,"first_name":"the hulk","updated_at":"","created_at":"2018-06-16T11:23:58.000Z"},"company":{"name":"iron man","notes":"the something dog leapt over the lazy fox"},"campaign":{"id":987,"name":"triggered event"},"datetime":"2018-03-07T14:28:16.000Z"}}}"""
         ),
         ContentType.some,
         Shared.cljSource,
@@ -79,7 +79,7 @@ class MarketoAdapterSpec extends Specification with DataTables with ValidationMa
     MarketoAdapter.toRawEvents(payload) must beSuccessful(expected)
   }
 
-  def e3 = {
+  def e2 = {
     val payload = CollectorPayload(Shared.api, Nil, ContentType.some, None, Shared.cljSource, Shared.context)
     MarketoAdapter.toRawEvents(payload) must beFailing(
       NonEmptyList("Request body is empty: no Marketo event to process"))

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/MarketoAdapterSpec.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/MarketoAdapterSpec.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2012-2014 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.common
+package adapters
+package registry
+
+// Joda-Time
+import org.joda.time.DateTime
+
+// Scalaz
+import scalaz._
+import Scalaz._
+
+// json4s
+import org.json4s._
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+import org.json4s.scalaz.JsonScalaz._
+
+// Snowplow
+import loaders.{
+  CollectorApi,
+  CollectorSource,
+  CollectorContext,
+  CollectorPayload
+}
+import utils.ConversionUtils
+import SpecHelpers._
+
+// Specs2
+import org.specs2.{Specification, ScalaCheck}
+import org.specs2.matcher.DataTables
+import org.specs2.scalaz.ValidationMatchers
+
+class MarketoAdapterSpec extends Specification with DataTables with ValidationMatchers with ScalaCheck { def is = s2"""
+  This is a specification to test the MarketoAdapter functionality
+  toRawEvents must return a success for a valid "event" type payload body being passed                $e1
+  toRawEvents must return a Failure Nel if a body is not specified in the payload                     $e3
+  """
+  //  toRawEvents must return a Nel Success for a supported event type                                    $e2
+
+  implicit val resolver = SpecHelpers.IgluResolver
+
+  object Shared {
+    val api = CollectorApi("com.marketo", "v1")
+    val cljSource = CollectorSource("clj-tomcat", "UTF-8", None)
+    val context = CollectorContext(DateTime.parse("2018-01-01T00:00:00.000+00:00").some, "37.157.33.123".some, None, None, Nil, None)
+  }
+
+  val ContentType = "application/json"
+
+  def e1 = {
+    val bodyStr = """{"campaign": {"id": 160, "name": "avengers assemble"}, "lead": {"acquisition_date": "2010-11-11 11:11:11", "black_listed": false, "first_name": "the hulk", "updated_at": ""}, "company": {"name": "iron man", "notes": "the something dog leapt over the lazy fox"}, "campaign": {"id": 987, "name": "triggered event"}, "datetime": "2018-03-07 14:28:16"}"""
+    val payload = CollectorPayload(Shared.api, Nil, ContentType.some, bodyStr.some, Shared.cljSource, Shared.context)
+    val expected = NonEmptyList(
+        RawEvent(
+        Shared.api,
+        Map(
+          "tv" -> "com.marketo-v1",
+          "e" -> "ue",
+          "p" -> "srv",
+          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.marketo/event/jsonschema/1-0-0","data":{"campaign":{"id":160,"name":"avengers assemble"},"lead":{"acquisition_date":"2010-11-11T11:11:11.000Z","black_listed":false,"first_name":"the hulk","updated_at":""},"company":{"name":"iron man","notes":"the something dog leapt over the lazy fox"},"campaign":{"id":987,"name":"triggered event"},"datetime":"2018-03-07T14:28:16.000Z"}}}"""),
+        ContentType.some,
+        Shared.cljSource,
+        Shared.context))
+    MarketoAdapter.toRawEvents(payload) must beSuccessful(expected)
+  }
+
+  /*def e2 =
+    "SPEC NAME"                 || "SCHEMA TYPE"    | "EXPECTED SCHEMA"                                 |
+    "Valid, type event"         !! "event"          ! "iglu:com.marketo/event/jsonschema/1-0-0"         |> {
+      (_, schema, expected) =>
+        val body = "{\"type\":\"" + schema + "\"}"
+        val payload = CollectorPayload(Shared.api, Nil, ContentType.some, body.some, Shared.cljSource, Shared.context)
+        val expectedJson = "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"" + expected + "\",\"data\":{}}}"
+        val actual = MarketoAdapter.toRawEvents(payload)
+        actual must beSuccessful(NonEmptyList(RawEvent(Shared.api, Map("tv" -> "com.marketo-v1", "e" -> "ue", "p" -> "srv", "ue_pr" -> expectedJson), ContentType.some, Shared.cljSource, Shared.context)))
+  }*/
+
+  def e3 = {  
+    val payload = CollectorPayload(Shared.api, Nil, ContentType.some, None, Shared.cljSource, Shared.context)
+    MarketoAdapter.toRawEvents(payload) must beFailing(NonEmptyList("Request body is empty: no Marketo event to process"))
+  }
+}


### PR DESCRIPTION
Adapter for the marketing platform Marketo. Just the single webhook payload event type (without an actual "type" field). Only field transformation are converting date-times to a valid format. JSON schema can be found [here](https://github.com/snowflake-analytics/iglu-central/blob/marketo/schemas/com.marketo/event/jsonschema/1-0-0).