### PR TITLE
Adding Vero adapter to enrichment

### DIFF
--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/AdapterRegistry.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/AdapterRegistry.scala
@@ -53,7 +53,7 @@ object AdapterRegistry {
     val StatusGator     = "com.statusgator"
     val Unbounce        = "com.unbounce"
     val UrbanAirship    = "com.urbanairship.connect"
-    val Vero            = "com.vero"
+    val Vero            = "com.getvero"
   }
 
   /**

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/AdapterRegistry.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/AdapterRegistry.scala
@@ -53,6 +53,7 @@ object AdapterRegistry {
     val StatusGator     = "com.statusgator"
     val Unbounce        = "com.unbounce"
     val UrbanAirship    = "com.urbanairship.connect"
+    val Vero            = "com.vero"
   }
 
   /**
@@ -87,6 +88,7 @@ object AdapterRegistry {
       case (Vendor.StatusGator, "v1")           => StatusGatorAdapter.toRawEvents(payload)
       case (Vendor.Unbounce, "v1")              => UnbounceAdapter.toRawEvents(payload)
       case (Vendor.UrbanAirship, "v1")          => UrbanAirshipAdapter.toRawEvents(payload)
+      case (Vendor.Vero, "v1")                  => VeroAdapter.toRawEvents(payload)
       case _ =>
         s"Payload with vendor ${payload.api.vendor} and version ${payload.api.version} not supported by this version of Scala Common Enrich".failNel
     }

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/VeroAdapter.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/VeroAdapter.scala
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2018 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics
+package snowplow
+package enrich
+package common
+package adapters
+package registry
+
+// Java
+import com.fasterxml.jackson.core.JsonParseException
+
+// Scalaz
+import scalaz.Scalaz._
+
+// json4s
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+
+// Iglu
+import com.snowplowanalytics.iglu.client.{Resolver, SchemaKey}
+
+// Joda Time
+import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
+
+// This project
+import com.snowplowanalytics.snowplow.enrich.common.loaders.CollectorPayload
+import com.snowplowanalytics.snowplow.enrich.common.utils.{JsonUtils => JU}
+
+/**
+ * Transforms a collector payload which conforms to
+ * a known version of the Vero webhook
+ * into raw events.
+ */
+object VeroAdapter extends Adapter {
+
+  // Vendor name for Failure Message
+  private val VendorName = "Vero"
+
+  // Expected content type for a request body
+  private val ContentType = "application/json"
+
+  // Tracker version for an Vero webhook
+  private val TrackerVersion = "com.getvero-v1"
+
+  // Schemas for reverse-engineering a Snowplow unstructured event
+  private val EventSchemaMap = Map(
+    "bounced"      -> SchemaKey("com.getvero", "bounced", "jsonschema", "1-0-0").toSchemaUri,
+    "clicked"      -> SchemaKey("com.getvero", "clicked", "jsonschema", "1-0-0").toSchemaUri,
+    "delivered"    -> SchemaKey("com.getvero", "delivered", "jsonschema", "1-0-0").toSchemaUri,
+    "opened"       -> SchemaKey("com.getvero", "opened", "jsonschema", "1-0-0").toSchemaUri,
+    "sent"         -> SchemaKey("com.getvero", "sent", "jsonschema", "1-0-0").toSchemaUri,
+    "unsubscribed" -> SchemaKey("com.getvero", "unsubscribed", "jsonschema", "1-0-0").toSchemaUri,
+    "user_created" -> SchemaKey("com.getvero", "created", "jsonschema", "1-0-0").toSchemaUri,
+    "user_updated" -> SchemaKey("com.getvero", "updated", "jsonschema", "1-0-0").toSchemaUri
+  )
+
+  /**
+   * Converts a payload into a single validated event
+   * Expects a valid json returns failure if one is not present
+   * For "user_updated" events the field is named "action" instead of "type"
+   * in which case the event type will be set to Some("user_updated")
+   *
+   * @param body_json Payload body that is sent by Vero
+   * @param payload The details of the payload
+   * @return a Validation boxing either a NEL of RawEvents on
+   *         Success, or a NEL of Failure Strings
+   */
+  private def payloadBodyToEvent(body_json: String, payload: CollectorPayload): Validated[RawEvent] =
+    try {
+      val parsed    = parse(body_json)
+      val eventType = (parsed \ "type").extractOpt[String].orElse(Some("user_updated"))
+      val formattedEvent = eventType match {
+        case Some("user_updated") => reformatParameters(parsed)
+        case _ => {
+          cleanupJsonEventValues(
+            parsed,
+            ("type", eventType.get).some,
+            eventType.get.concat("_at")
+          )
+        }
+      }
+
+      val reformattedEvent = reformatParameters(formattedEvent)
+
+      lookupSchema(eventType, VendorName, EventSchemaMap) map { schema =>
+        RawEvent(
+          api = payload.api,
+          parameters = toUnstructEventParams(
+            TrackerVersion,
+            toMap(payload.querystring),
+            schema,
+            reformattedEvent,
+            "srv"
+          ),
+          contentType = payload.contentType,
+          source      = payload.source,
+          context     = payload.context
+        )
+      }
+
+    } catch {
+      case e: JsonParseException => {
+        val exception = JU.stripInstanceEtc(e.toString).orNull
+        s"$VendorName event failed to parse into JSON: [$exception]".failureNel
+      }
+    }
+
+  /**
+   * Converts a CollectorPayload instance into raw events.
+   * A Vero API payload only contains a single event.
+   * We expect the type parameter to match the supported events, else
+   * we have an unsupported event type.
+   *
+   * @param payload The CollectorPayload containing one or more
+   *        raw events as collected by a Snowplow collector
+   * @param resolver (implicit) The Iglu resolver used for
+   *        schema lookup and validation. Not used
+   * @return a Validation boxing either a NEL of RawEvents on
+   *         Success, or a NEL of Failure Strings
+   */
+  def toRawEvents(payload: CollectorPayload)(implicit resolver: Resolver): ValidatedRawEvents =
+    (payload.body, payload.contentType) match {
+      case (None, _) => s"Request body is empty: no $VendorName event to process".failureNel
+      case (Some(body), _) => {
+        val event = payloadBodyToEvent(body, payload)
+        rawEventsListProcessor(List(event))
+      }
+    }
+
+  /**
+   * Returns an updated Vero event JSON where
+   * the "action" field has been removed
+   * and "triggered_at" fields' values have been converted
+   *
+   * @param json The event JSON which we need to
+   *        update values for
+   * @return the updated JSON with updated fields and values
+   */
+  private[registry] def reformatParameters(json: JValue): JValue = {
+
+    def toStringField(value: Long): JString = {
+      val dt: DateTime = new DateTime(value)
+      JString(JsonSchemaDateTimeFormat.print(dt))
+    }
+
+    val j1 = json.transformField {
+      case ("triggered_at", JInt(value)) => ("triggered_at", toStringField(value.toLong * 1000))
+    }
+    val j2 = j1.removeField {
+      case ("action", _) => true
+      case _             => false
+    }
+    j2
+  }
+}

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/VeroAdapter.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/VeroAdapter.scala
@@ -72,14 +72,14 @@ object VeroAdapter extends Adapter {
    * For "user_updated" events the field is named "action" instead of "type"
    * in which case the event type will be set to Some("user_updated")
    *
-   * @param body_json Payload body that is sent by Vero
+   * @param json Payload body that is sent by Vero
    * @param payload The details of the payload
    * @return a Validation boxing either a NEL of RawEvents on
    *         Success, or a NEL of Failure Strings
    */
-  private def payloadBodyToEvent(body_json: String, payload: CollectorPayload): Validated[RawEvent] =
+  private def payloadBodyToEvent(json: String, payload: CollectorPayload): Validated[RawEvent] =
     try {
-      val parsed    = parse(body_json)
+      val parsed    = parse(json)
       val eventType = (parsed \ "type").extractOpt[String].orElse(Some("user_updated"))
       val formattedEvent = eventType match {
         case Some("user_updated") => reformatParameters(parsed)
@@ -87,7 +87,7 @@ object VeroAdapter extends Adapter {
           cleanupJsonEventValues(
             parsed,
             ("type", eventType.get).some,
-            eventType.get.concat("_at")
+            s"$eventType_at")
           )
         }
       }
@@ -148,7 +148,7 @@ object VeroAdapter extends Adapter {
    *        update values for
    * @return the updated JSON with updated fields and values
    */
-  private[registry] def reformatParameters(json: JValue): JValue = {
+  def reformatParameters(json: JValue): JValue = {
 
     def toStringField(value: Long): JString = {
       val dt: DateTime = new DateTime(value)

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/VeroAdapter.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/VeroAdapter.scala
@@ -86,9 +86,8 @@ object VeroAdapter extends Adapter {
         case Failure(e) => s"$VendorName event failed to parse into JSON: [${e.getMessage}]".failureNel
       }
       eventType = parsed.toOption.flatMap(p => (p \ "type").extractOpt[String]).getOrElse("user_updated")
-      formattedEvent = 
-        if (eventType == "user_updated") parsed
-        else cleanupJsonEventValues(parsed, ("type", eventType).some, s"${eventType}_at")
+      formattedEvent = if (eventType == "user_updated") parsed
+      else cleanupJsonEventValues(parsed, ("type", eventType).some, s"${eventType}_at")
       reformattedEvent = reformatParameters(formattedEvent)
       schema <- lookupSchema(eventType.some, VendorName, EventSchemaMap)
       params = toUnstructEventParams(TrackerVersion, toMap(payload.querystring), schema, reformattedEvent, "srv")
@@ -112,7 +111,7 @@ object VeroAdapter extends Adapter {
    * @return a Validation boxing either a NEL of RawEvents on
    *         Success, or a NEL of Failure Strings
    */
-  def toRawEvents(payload: CollectorPayload)(implicit resolver: Resolver): ValidatedRawEvents =
+  override def toRawEvents(payload: CollectorPayload)(implicit resolver: Resolver): ValidatedRawEvents =
     (payload.body, payload.contentType) match {
       case (None, _) => s"Request body is empty: no $VendorName event to process".failureNel
       case (Some(body), _) => {

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/VeroAdapter.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/VeroAdapter.scala
@@ -83,7 +83,7 @@ object VeroAdapter extends Adapter {
         case Success(p) => p.successNel
         case Failure(e) => s"$VendorName event failed to parse into JSON: [${e.getMessage}]".failureNel
       }
-      eventType = (parsed \ "type").extract[String]
+      eventType        = (parsed \ "type").extract[String]
       formattedEvent   = cleanupJsonEventValues(parsed, ("type", eventType).some, s"${eventType}_at")
       reformattedEvent = reformatParameters(formattedEvent)
       schema <- lookupSchema(eventType.some, VendorName, EventSchemaMap)

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/VeroAdapter.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/VeroAdapter.scala
@@ -82,7 +82,7 @@ object VeroAdapter extends Adapter {
       val parsed    = parse(json)
       val eventType = (parsed \ "type").extractOpt[String].orElse(Some("user_updated"))
       val formattedEvent = eventType match {
-        case Some("user_updated") => reformatParameters(parsed)
+        case Some("user_updated") => parsed
         case _ => {
           cleanupJsonEventValues(
             parsed,

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/VeroAdapterSpec.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/VeroAdapterSpec.scala
@@ -198,7 +198,7 @@ class VeroAdapterSpec extends Specification with DataTables with ValidationMatch
           "tv"    -> "com.getvero-v1",
           "e"     -> "ue",
           "p"     -> "srv",
-          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.getvero/created/jsonschema/1-0-0","data":{"user":{"id":123,"email":"steve@getvero.com"},"changes":{"_tags":{"add":["active-customer"],"remove":["unactive-180-days"]}}}}}"""
+          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.getvero/created/jsonschema/1-0-0","data":{"user":{"id":123,"email":"steve@getvero.com"},"changes":{"tags":{"add":["active-customer"],"remove":["unactive-180-days"]}}}}}"""
         ),
         ContentType.some,
         Shared.cljSource,
@@ -209,7 +209,7 @@ class VeroAdapterSpec extends Specification with DataTables with ValidationMatch
 
   def e8 = {
     val bodyStr =
-      """{"action": "user_updated", "id": "peter", "email": "peter@test.com", "changes": {"id": "peter", "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/604.5.6 (KHTML, like Gecko) Version/11.0.3 Safari/604.5.6", "platform": "MacIntel", "language": "en-AU", "timezone": 11}}"""
+      """{"type": "user_updated", "user": {"id": 123, "email": "steve@getvero.com"}, "changes": {"_tags": {"add": ["active-customer"], "remove": ["unactive-180-days"]}}}"""
     val payload = CollectorPayload(Shared.api, Nil, ContentType.some, bodyStr.some, Shared.cljSource, Shared.context)
     val expected = NonEmptyList(
       RawEvent(
@@ -218,7 +218,7 @@ class VeroAdapterSpec extends Specification with DataTables with ValidationMatch
           "tv"    -> "com.getvero-v1",
           "e"     -> "ue",
           "p"     -> "srv",
-          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.getvero/updated/jsonschema/1-0-0","data":{"id":"peter","email":"peter@test.com","changes":{"id":"peter","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/604.5.6 (KHTML, like Gecko) Version/11.0.3 Safari/604.5.6","platform":"MacIntel","language":"en-AU","timezone":11}}}}"""
+          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.getvero/updated/jsonschema/1-0-0","data":{"user":{"id":123,"email":"steve@getvero.com"},"changes":{"tags":{"add":["active-customer"],"remove":["unactive-180-days"]}}}}}"""
         ),
         ContentType.some,
         Shared.cljSource,
@@ -237,10 +237,7 @@ class VeroAdapterSpec extends Specification with DataTables with ValidationMatch
       "Valid, type created"      !! "user_created" ! "iglu:com.getvero/created/jsonschema/1-0-0" |
       "Valid, type updated"      !! "user_updated" ! "iglu:com.getvero/updated/jsonschema/1-0-0" |
       "Valid, type bounced"      !! "bounced"      ! "iglu:com.getvero/bounced/jsonschema/1-0-0" |> { (_, schema, expected) =>
-      val body = schema match {
-        case "user_updated" => "{\"action\":\"" + schema + "\"}"
-        case _              => "{\"type\":\""   + schema + "\"}"
-      }
+      val body         = "{\"type\":\"" + schema + "\"}"
       val payload      = CollectorPayload(Shared.api, Nil, ContentType.some, body.some, Shared.cljSource, Shared.context)
       val expectedJson = "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"" + expected + "\",\"data\":{}}}"
       val actual       = VeroAdapter.toRawEvents(payload)

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/VeroAdapterSpec.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/VeroAdapterSpec.scala
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2018 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.common
+package adapters
+package registry
+
+// Joda-Time
+import org.joda.time.DateTime
+
+// Scalaz
+import scalaz._
+import Scalaz._
+
+// json4s
+import org.json4s._
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+import org.json4s.scalaz.JsonScalaz._
+
+// Snowplow
+import loaders.{CollectorApi, CollectorContext, CollectorPayload, CollectorSource}
+import utils.ConversionUtils
+import SpecHelpers._
+
+// Specs2
+import org.specs2.{ScalaCheck, Specification}
+import org.specs2.matcher.DataTables
+import org.specs2.scalaz.ValidationMatchers
+
+class VeroAdapterSpec extends Specification with DataTables with ValidationMatchers with ScalaCheck {
+  def is = s2"""
+  This is a specification to test the VeroAdapter functionality
+  toRawEvents must return a success for a valid "sent" type payload body being passed                $e1
+  toRawEvents must return a success for a valid "delivered" type payload body being passed           $e2
+  toRawEvents must return a success for a valid "opened" type payload body being passed              $e3
+  toRawEvents must return a success for a valid "clicked" type payload body being passed             $e4
+  toRawEvents must return a success for a valid "bounced" type payload body being passed             $e5
+  toRawEvents must return a success for a valid "unsubscribed" type payload body being passed        $e6
+  toRawEvents must return a success for a valid "created" type payload body being passed             $e7
+  toRawEvents must return a success for a valid "updated" type payload body being passed             $e8
+  toRawEvents must return a Nel Success for a supported event type                                   $e9
+  toRawEvents must return a Failure Nel if a body is not specified in the payload                    $e10
+  """
+
+  implicit val resolver = SpecHelpers.IgluResolver
+
+  object Shared {
+    val api       = CollectorApi("com.getvero", "v1")
+    val cljSource = CollectorSource("clj-tomcat", "UTF-8", None)
+    val context = CollectorContext(DateTime.parse("2018-01-01T00:00:00.000+00:00").some,
+                                   "37.157.33.123".some,
+                                   None,
+                                   None,
+                                   Nil,
+                                   None)
+  }
+
+  val ContentType = "application/json"
+
+  def e1 = {
+    val bodyStr =
+      """{"sent_at": 1435016238, "event": {"name": "Test event", "triggered_at": 1424012238}, "type": "sent", "user": {"id": 123, "email": "steve@getvero.com"},"campaign": {"id": 987, "type": "transactional", "name": "Order confirmation", "subject": "Your order is being processed", "trigger-event": "purchased item", "permalink": "http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25", "variation": "Variation A", "tags": "tag 1, tag 2"}}"""
+    val payload = CollectorPayload(Shared.api, Nil, ContentType.some, bodyStr.some, Shared.cljSource, Shared.context)
+    val expected = NonEmptyList(
+      RawEvent(
+        Shared.api,
+        Map(
+          "tv"    -> "com.getvero-v1",
+          "e"     -> "ue",
+          "p"     -> "srv",
+          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.getvero/sent/jsonschema/1-0-0","data":{"sent_at":"2015-06-22T23:37:18.000Z","event":{"name":"Test event","triggered_at":"2015-02-15T14:57:18.000Z"},"user":{"id":123,"email":"steve@getvero.com"},"campaign":{"id":987,"type":"transactional","name":"Order confirmation","subject":"Your order is being processed","trigger-event":"purchased item","permalink":"http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25","variation":"Variation A","tags":"tag 1, tag 2"}}}}"""
+        ),
+        ContentType.some,
+        Shared.cljSource,
+        Shared.context
+      ))
+    VeroAdapter.toRawEvents(payload) must beSuccessful(expected)
+  }
+
+  def e2 = {
+    val bodyStr =
+      """{"delivered_at": 1435016238, "sender_ip": "127.0.0.1", "message_id": "20130920062934.21270.53268@vero.com", "event":{"name":"Test event","triggered_at":1424012238}, "type": "delivered", "user": {"id": 123, "email": "steve@getvero.com"},"campaign": {"id": 987, "type": "transactional", "name": "Order confirmation", "subject": "Your order is being processed", "trigger-event": "purchased item", "permalink": "http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25", "variation": "Variation A", "tags": "tag 1, tag 2"}}"""
+    val payload = CollectorPayload(Shared.api, Nil, ContentType.some, bodyStr.some, Shared.cljSource, Shared.context)
+    val expected = NonEmptyList(
+      RawEvent(
+        Shared.api,
+        Map(
+          "tv"    -> "com.getvero-v1",
+          "e"     -> "ue",
+          "p"     -> "srv",
+          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.getvero/delivered/jsonschema/1-0-0","data":{"delivered_at":"2015-06-22T23:37:18.000Z","sender_ip":"127.0.0.1","message_id":"20130920062934.21270.53268@vero.com","event":{"name":"Test event","triggered_at":"2015-02-15T14:57:18.000Z"},"user":{"id":123,"email":"steve@getvero.com"},"campaign":{"id":987,"type":"transactional","name":"Order confirmation","subject":"Your order is being processed","trigger-event":"purchased item","permalink":"http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25","variation":"Variation A","tags":"tag 1, tag 2"}}}}"""
+        ),
+        ContentType.some,
+        Shared.cljSource,
+        Shared.context
+      ))
+    VeroAdapter.toRawEvents(payload) must beSuccessful(expected)
+  }
+
+  def e3 = {
+    val bodyStr =
+      """{"opened_at": 1435016238, "user_agent":"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)", "message_id": "20130920062934.21270.53268@vero.com", "event": {"name": "Test event", "triggered_at": 1424012238}, "type": "opened", "user": {"id": 123, "email": "steve@getvero.com"},"campaign": {"id": 987, "type": "transactional", "name": "Order confirmation", "subject": "Your order is being processed", "trigger-event": "purchased item", "permalink": "http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25", "variation": "Variation A", "tags": "tag 1, tag 2"}}"""
+    val payload = CollectorPayload(Shared.api, Nil, ContentType.some, bodyStr.some, Shared.cljSource, Shared.context)
+    val expected = NonEmptyList(
+      RawEvent(
+        Shared.api,
+        Map(
+          "tv"    -> "com.getvero-v1",
+          "e"     -> "ue",
+          "p"     -> "srv",
+          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.getvero/opened/jsonschema/1-0-0","data":{"opened_at":"2015-06-22T23:37:18.000Z","user_agent":"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)","message_id":"20130920062934.21270.53268@vero.com","event":{"name":"Test event","triggered_at":"2015-02-15T14:57:18.000Z"},"user":{"id":123,"email":"steve@getvero.com"},"campaign":{"id":987,"type":"transactional","name":"Order confirmation","subject":"Your order is being processed","trigger-event":"purchased item","permalink":"http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25","variation":"Variation A","tags":"tag 1, tag 2"}}}}"""
+        ),
+        ContentType.some,
+        Shared.cljSource,
+        Shared.context
+      ))
+    VeroAdapter.toRawEvents(payload) must beSuccessful(expected)
+  }
+
+  def e4 = {
+    val bodyStr =
+      """{"clicked_at": 1435016238, "user_agent":"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)", "message_id": "20130920062934.21270.53268@vero.com", "event": {"name": "Test event", "triggered_at": 1424012238}, "type": "clicked", "user": {"id": 123, "email": "steve@getvero.com"},"campaign": {"id": 987, "type": "transactional", "name": "Order confirmation", "subject": "Your order is being processed", "trigger-event": "purchased item", "permalink": "http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25", "variation": "Variation A", "tags": "tag 1, tag 2"}}"""
+    val payload = CollectorPayload(Shared.api, Nil, ContentType.some, bodyStr.some, Shared.cljSource, Shared.context)
+    val expected = NonEmptyList(
+      RawEvent(
+        Shared.api,
+        Map(
+          "tv"    -> "com.getvero-v1",
+          "e"     -> "ue",
+          "p"     -> "srv",
+          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.getvero/clicked/jsonschema/1-0-0","data":{"clicked_at":"2015-06-22T23:37:18.000Z","user_agent":"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)","message_id":"20130920062934.21270.53268@vero.com","event":{"name":"Test event","triggered_at":"2015-02-15T14:57:18.000Z"},"user":{"id":123,"email":"steve@getvero.com"},"campaign":{"id":987,"type":"transactional","name":"Order confirmation","subject":"Your order is being processed","trigger-event":"purchased item","permalink":"http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25","variation":"Variation A","tags":"tag 1, tag 2"}}}}"""
+        ),
+        ContentType.some,
+        Shared.cljSource,
+        Shared.context
+      ))
+    VeroAdapter.toRawEvents(payload) must beSuccessful(expected)
+  }
+
+  def e5 = {
+    val bodyStr =
+      """{"bounced_at": 1435016238, "bounce_type":"hard", "bounce_code": "521", "bounce_message": "521 5.2.1 :  AOL will not accept delivery of this message.", "message_id": "20130920062934.21270.53268@vero.com", "event": {"name": "Test event", "triggered_at": 1424012238}, "type": "bounced", "user": {"id": 123, "email": "steve@getvero.com"},"campaign": {"id": 987, "type": "transactional", "name": "Order confirmation", "subject": "Your order is being processed", "trigger-event": "purchased item", "permalink": "http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25", "variation": "Variation A"}}"""
+    val payload = CollectorPayload(Shared.api, Nil, ContentType.some, bodyStr.some, Shared.cljSource, Shared.context)
+    val expected = NonEmptyList(
+      RawEvent(
+        Shared.api,
+        Map(
+          "tv"    -> "com.getvero-v1",
+          "e"     -> "ue",
+          "p"     -> "srv",
+          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.getvero/bounced/jsonschema/1-0-0","data":{"bounced_at":"2015-06-22T23:37:18.000Z","bounce_type":"hard","bounce_code":"521","bounce_message":"521 5.2.1 :  AOL will not accept delivery of this message.","message_id":"20130920062934.21270.53268@vero.com","event":{"name":"Test event","triggered_at":"2015-02-15T14:57:18.000Z"},"user":{"id":123,"email":"steve@getvero.com"},"campaign":{"id":987,"type":"transactional","name":"Order confirmation","subject":"Your order is being processed","trigger-event":"purchased item","permalink":"http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25","variation":"Variation A"}}}}"""
+        ),
+        ContentType.some,
+        Shared.cljSource,
+        Shared.context
+      ))
+    VeroAdapter.toRawEvents(payload) must beSuccessful(expected)
+  }
+
+  def e6 = {
+    val bodyStr =
+      """{"unsubscribed_at": 1435016238, "type": "unsubscribed", "user": {"id": 123, "email": "steve@getvero.com"}}"""
+    val payload = CollectorPayload(Shared.api, Nil, ContentType.some, bodyStr.some, Shared.cljSource, Shared.context)
+    val expected = NonEmptyList(
+      RawEvent(
+        Shared.api,
+        Map(
+          "tv"    -> "com.getvero-v1",
+          "e"     -> "ue",
+          "p"     -> "srv",
+          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.getvero/unsubscribed/jsonschema/1-0-0","data":{"unsubscribed_at":"2015-06-22T23:37:18.000Z","user":{"id":123,"email":"steve@getvero.com"}}}}"""
+        ),
+        ContentType.some,
+        Shared.cljSource,
+        Shared.context
+      ))
+    VeroAdapter.toRawEvents(payload) must beSuccessful(expected)
+  }
+
+  def e7 = {
+    val bodyStr =
+      """{"type": "user_created", "user": {"id": 123, "email": "steve@getvero.com"}, "changes": {"_tags": {"add": ["active-customer"], "remove": ["unactive-180-days"]}}}"""
+    val payload = CollectorPayload(Shared.api, Nil, ContentType.some, bodyStr.some, Shared.cljSource, Shared.context)
+    val expected = NonEmptyList(
+      RawEvent(
+        Shared.api,
+        Map(
+          "tv"    -> "com.getvero-v1",
+          "e"     -> "ue",
+          "p"     -> "srv",
+          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.getvero/created/jsonschema/1-0-0","data":{"user":{"id":123,"email":"steve@getvero.com"},"changes":{"_tags":{"add":["active-customer"],"remove":["unactive-180-days"]}}}}}"""
+        ),
+        ContentType.some,
+        Shared.cljSource,
+        Shared.context
+      ))
+    VeroAdapter.toRawEvents(payload) must beSuccessful(expected)
+  }
+
+  def e8 = {
+    val bodyStr =
+      """{"action": "user_updated", "id": "peter", "email": "peter@test.com", "changes": {"id": "peter", "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/604.5.6 (KHTML, like Gecko) Version/11.0.3 Safari/604.5.6", "platform": "MacIntel", "language": "en-AU", "timezone": 11}}"""
+    val payload = CollectorPayload(Shared.api, Nil, ContentType.some, bodyStr.some, Shared.cljSource, Shared.context)
+    val expected = NonEmptyList(
+      RawEvent(
+        Shared.api,
+        Map(
+          "tv"    -> "com.getvero-v1",
+          "e"     -> "ue",
+          "p"     -> "srv",
+          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.getvero/updated/jsonschema/1-0-0","data":{"id":"peter","email":"peter@test.com","changes":{"id":"peter","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/604.5.6 (KHTML, like Gecko) Version/11.0.3 Safari/604.5.6","platform":"MacIntel","language":"en-AU","timezone":11}}}}"""
+        ),
+        ContentType.some,
+        Shared.cljSource,
+        Shared.context
+      ))
+    VeroAdapter.toRawEvents(payload) must beSuccessful(expected)
+  }
+
+  def e9 =
+    "SPEC NAME"                  || "SCHEMA TYPE"  | "EXPECTED SCHEMA" |
+      "Valid, type sent"         !! "sent"         ! "iglu:com.getvero/sent/jsonschema/1-0-0" |
+      "Valid, type unsubscribed" !! "unsubscribed" ! "iglu:com.getvero/unsubscribed/jsonschema/1-0-0" |
+      "Valid, type delivered"    !! "delivered"    ! "iglu:com.getvero/delivered/jsonschema/1-0-0" |
+      "Valid, type opened"       !! "opened"       ! "iglu:com.getvero/opened/jsonschema/1-0-0" |
+      "Valid, type clicked"      !! "clicked"      ! "iglu:com.getvero/clicked/jsonschema/1-0-0" |
+      "Valid, type created"      !! "user_created" ! "iglu:com.getvero/created/jsonschema/1-0-0" |
+      "Valid, type updated"      !! "user_updated" ! "iglu:com.getvero/updated/jsonschema/1-0-0" |
+      "Valid, type bounced"      !! "bounced"      ! "iglu:com.getvero/bounced/jsonschema/1-0-0" |> { (_, schema, expected) =>
+      val body = schema match {
+        case "user_updated" => "{\"action\":\"" + schema + "\"}"
+        case _              => "{\"type\":\""   + schema + "\"}"
+      }
+      val payload      = CollectorPayload(Shared.api, Nil, ContentType.some, body.some, Shared.cljSource, Shared.context)
+      val expectedJson = "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"" + expected + "\",\"data\":{}}}"
+      val actual       = VeroAdapter.toRawEvents(payload)
+      actual must beSuccessful(
+        NonEmptyList(
+          RawEvent(Shared.api,
+                   Map("tv" -> "com.getvero-v1", "e" -> "ue", "p" -> "srv", "ue_pr" -> expectedJson),
+                   ContentType.some,
+                   Shared.cljSource,
+                   Shared.context)))
+    }
+
+  def e10 = {
+    val payload = CollectorPayload(Shared.api, Nil, ContentType.some, None, Shared.cljSource, Shared.context)
+    VeroAdapter.toRawEvents(payload) must beFailing(NonEmptyList("Request body is empty: no Vero event to process"))
+  }
+}

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/VeroAdapterSpec.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/VeroAdapterSpec.scala
@@ -189,7 +189,7 @@ class VeroAdapterSpec extends Specification with DataTables with ValidationMatch
 
   def e7 = {
     val bodyStr =
-      """{"type": "user_created", "user": {"id": 123, "email": "steve@getvero.com"}, "changes": {"_tags": {"add": ["active-customer"], "remove": ["unactive-180-days"]}}}"""
+      """{"type": "user_created", "user": {"id": 123, "email": "steve@getvero.com"}, "firstname": "Steve", "company": "Vero", "role": "Bot"}"""
     val payload = CollectorPayload(Shared.api, Nil, ContentType.some, bodyStr.some, Shared.cljSource, Shared.context)
     val expected = NonEmptyList(
       RawEvent(
@@ -198,7 +198,7 @@ class VeroAdapterSpec extends Specification with DataTables with ValidationMatch
           "tv"    -> "com.getvero-v1",
           "e"     -> "ue",
           "p"     -> "srv",
-          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.getvero/created/jsonschema/1-0-0","data":{"user":{"id":123,"email":"steve@getvero.com"},"changes":{"tags":{"add":["active-customer"],"remove":["unactive-180-days"]}}}}}"""
+          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.getvero/created/jsonschema/1-0-0","data":{"user":{"id":123,"email":"steve@getvero.com"},"firstname":"Steve","company":"Vero","role":"Bot"}}}"""
         ),
         ContentType.some,
         Shared.cljSource,


### PR DESCRIPTION
Adapter for Vero webhook events. "user_updated" event is unique in that the "type" field is named "action". Only other conversion needed outside of the cleanupJsonEventValues method are for all the date-time values in the "triggered_at" field.
Schemas this will be validated against can be found [here](https://github.com/snowflake-analytics/iglu-central/tree/vero/schemas/com.getvero).