### PR TITLE
Update config sample to clarify input location requirements

### DIFF
--- a/3-enrich/emr-etl-runner/config/config.yml.sample
+++ b/3-enrich/emr-etl-runner/config/config.yml.sample
@@ -9,9 +9,9 @@ aws:
       jsonpath_assets: # If you have defined your own JSON Schemas, add the s3:// path to your own JSON Path files in your own bucket here
       log: ADD HERE
       raw:
-        in:                  # This is a YAML array of one or more in buckets - you MUST use hyphens before each entry in the array, as below
-          - ADD HERE         # e.g. s3://my-old-collector-bucket
-          - ADD HERE         # e.g. s3://my-new-collector-bucket
+        in:                  # This is a YAML array of one or more in bucket log locations - you MUST use hyphens before each entry in the array, as below
+          - ADD HERE         # e.g. s3://my-old-collector-bucket/
+          - ADD HERE         # e.g. s3://my-new-collector-bucket/resources/environments/logs/publish/e-*******  # e-******* represents the Elastic Beanstalk Environment ID
         processing: ADD HERE
         archive: ADD HERE    # e.g. s3://my-archive-bucket/raw
       enriched:


### PR DESCRIPTION
Clarify config sample to save others the time we wasted tracking down the fact that the Elastic Beanstalk logs are too deep in the bucket for the ETL process to find them.

Leaving s3://my-old-collector-bucket/ as-is since I assume this must work for some use cases or it did at one point.

See https://discourse.snowplowanalytics.com/t/enrich-raw-events-fails-due-to-not-a-file-hdfs-clojure-connector-emr-etl-runner/1489  for details.