### PR TITLE
Scala Common Enrich: bump ua-parser to 1.4.0

### DIFF
--- a/3-enrich/scala-common-enrich/project/Dependencies.scala
+++ b/3-enrich/scala-common-enrich/project/Dependencies.scala
@@ -43,7 +43,7 @@ object Dependencies {
     val jacksonDatabind  = "2.2.3"
     val jsonValidator    = "2.2.3"
     val mavenArtifact    = "3.2.2"
-    val uaParser         = "1.3.0"
+    val uaParser         = "1.4.0"
     val postgresDriver   = "9.4.1208.jre7"
     val mysqlConnector   = "5.1.39"
     val jaywayJsonpath   = "2.4.0"
@@ -81,7 +81,7 @@ object Dependencies {
     val jacksonDatabind  = "com.fasterxml.jackson.core" %  "jackson-databind"          % V.jacksonDatabind
     val jsonValidator    = "com.github.fge"             %  "json-schema-validator"     % V.jsonValidator
     val mavenArtifact    = "org.apache.maven"           %  "maven-artifact"            % V.mavenArtifact
-    val uaParser         = "org.clojars.timewarrior"    %  "ua-parser"                 % V.uaParser
+    val uaParser         = "com.github.ua-parser"       %  "uap-java"                  % V.uaParser
     val postgresDriver   = "org.postgresql"             %  "postgresql"                % V.postgresDriver
     val mysqlConnector   = "mysql"                      %  "mysql-connector-java"      % V.mysqlConnector
     val jaywayJsonpath   = "com.jayway.jsonpath"        %  "json-path"                 % V.jaywayJsonpath


### PR DESCRIPTION
This addresses issue #2931.

This also brings the default regex file to the latest as of May 2018.