### PR TITLE
Stream Enrich: fix configuration example (closes #3820)

### DIFF
--- a/3-enrich/stream-enrich/examples/config.hocon.sample
+++ b/3-enrich/stream-enrich/examples/config.hocon.sample
@@ -53,10 +53,10 @@ enrich {
       # 'kafka' for reading / writing to a Kafka topic
       # 'nsq' for reading / writing to a Nsq topic
       # 'stdin' for reading from stdin and writing to stdout and stderr
-      type =  {{ sinkType }}
+      enabled =  {{sinkType}}
 
       # Region where the streams are located (AWS region, pertinent to kinesis sink/source type)
-      # region = {{ region }}
+      # region = {{region}}
 
       # AWS credentials (pertinent to kinesis sink/source type)
       # If both are set to 'default', use the default AWS credentials provider chain.

--- a/3-enrich/stream-enrich/integration-tests/src/test/scala/com.snowplowanalytics.snowplow.enrich.stream/PiiEmitSpec.scala
+++ b/3-enrich/stream-enrich/integration-tests/src/test/scala/com.snowplowanalytics.snowplow.enrich.stream/PiiEmitSpec.scala
@@ -39,7 +39,7 @@ import com.hubspot.jinjava.Jinjava
 
 // This project
 import good._
-import model.StreamsConfig
+import model.{StreamsConfig, SourceSinkConfig}
 
 class PiiEmitSpec extends Specification with FutureMatchers {
 
@@ -83,6 +83,7 @@ class PiiEmitSpec extends Specification with FutureMatchers {
     "emit all events" in new KafkaIntegrationSpec {
       implicit private def hint[T]: ProductHint[T] =
         ProductHint[T](ConfigFieldMapping(CamelCase, CamelCase))
+      implicit val sourceSinkConfigHint = new FieldCoproductHint[SourceSinkConfig]("enabled")
 
       val parsedConfig = ConfigFactory.parseString(configInstance).resolve()
       val configObject = Try {


### PR DESCRIPTION
Our installation script worked with r105 and didn't work with r106. Turned out that this was the issue. 
The integration test was not working for the same reason. Had to fix it.

CC @nafid @zakipatel