### PR TITLE
#3831 Fix that adds \n at the end of every event

### DIFF
--- a/3-enrich/stream-enrich/kinesis/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/sinks/KinesisSink.scala
+++ b/3-enrich/stream-enrich/kinesis/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/sinks/KinesisSink.scala
@@ -181,7 +181,7 @@ class KinesisSink(
    * @return whether to send the stored events to Kinesis
    */
   override def storeEnrichedEvents(events: List[(String, String)]): Boolean = {
-    val wrappedEvents = events.map(e => ByteBuffer.wrap(e._1.getBytes(UTF_8)) -> e._2)
+    val wrappedEvents = events.map(e => ByteBuffer.wrap(s"${e._1}\n".getBytes(UTF_8)) -> e._2)
     wrappedEvents.foreach(EventStorage.addEvent(_))
     if (!EventStorage.currentBatch.isEmpty && System.currentTimeMillis() > nextRequestTime) {
       nextRequestTime = System.currentTimeMillis() + TimeThreshold


### PR DESCRIPTION
It closes #3831 adding a '\n' to the end of the final event (that it is a TSV)