### PR TITLE
Scala Common Enrich: move away from user-agent-utils (closes #3591)

### DIFF
--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/UserAgentUtilsEnrichment.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/UserAgentUtilsEnrichment.scala
@@ -26,6 +26,9 @@ import scala.util.control.NonFatal
 import scalaz._
 import Scalaz._
 
+// Logging
+import org.slf4j.LoggerFactory
+
 // UserAgentUtils
 import eu.bitwalker.useragentutils._
 
@@ -41,10 +44,15 @@ import utils.ScalazJson4sUtils
 object UserAgentUtilsEnrichmentConfig extends ParseableEnrichment {
 
   val supportedSchema = SchemaCriterion("com.snowplowanalytics.snowplow", "user_agent_utils_config", "jsonschema", 1, 0)
+  val log             = LoggerFactory.getLogger(getClass())
 
   // Creates a UserAgentUtilsEnrichment instance from a JValue
-  def parse(config: JValue, schemaKey: SchemaKey): ValidatedNelMessage[UserAgentUtilsEnrichment.type] =
+  def parse(config: JValue, schemaKey: SchemaKey): ValidatedNelMessage[UserAgentUtilsEnrichment.type] = {
+    log.warn(
+      s"user_agent_utils enrichment is deprecated. Please visit here for more information: " +
+        s"https://github.com/snowplow/snowplow/wiki/user-agent-utils-enrichment")
     isParseable(config, schemaKey).map(_ => UserAgentUtilsEnrichment)
+  }
 }
 
 /**


### PR DESCRIPTION
This is the first step discussed in the ticket. The next steps (refactoring events table and stop populating the 10 fields that are generated by this enrichment) would not fit in this ticket. So I think this PR will close the issue, too. 

Making sure that this enrichment and its fields are gone is important for us since they count for ~%8 of all main table fields and the volume of the data is significant when considering larger scale.

CC: @nafid 