### PR TITLE
Scala Common Enrich: Support POST requests in API Request enrichment

### DIFF
--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/apirequest/ApiRequestEnrichment.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/apirequest/ApiRequestEnrichment.scala
@@ -19,21 +19,24 @@ package apirequest
 // Maven Artifact
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion
 
+// Java
+import java.util.UUID
+
 // Scalaz
+import scalaz.Scalaz._
 import scalaz._
-import Scalaz._
 
 // json4s
-import org.json4s._
 import org.json4s.JsonDSL._
+import org.json4s._
 import org.json4s.jackson.JsonMethods.fromJsonNode
 
 // Iglu
 import com.snowplowanalytics.iglu.client.{SchemaCriterion, SchemaKey}
 
 // This project
-import outputs.EnrichedEvent
-import utils.{HttpClient, ScalazJson4sUtils}
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+import com.snowplowanalytics.snowplow.enrich.common.utils.ScalazJson4sUtils
 
 /**
  * Lets us create an ApiRequestEnrichmentConfig from a JValue
@@ -115,7 +118,8 @@ case class ApiRequestEnrichment(inputs: List[Input], api: HttpApi, outputs: List
       templateContext <- validInputs.toList
       url             <- api.buildUrl(templateContext).toList
       output          <- outputs
-    } yield cachedOrRequest(url, output).leftMap(_.toString)
+      body = api.buildBody(templateContext)
+    } yield cachedOrRequest(url, body, output).leftMap(_.toString)
     result.sequenceU
   }
 
@@ -126,14 +130,16 @@ case class ApiRequestEnrichment(inputs: List[Input], api: HttpApi, outputs: List
    * @param output currently processing output
    * @return validated JObject, in case of success ready to be attached to derived contexts
    */
-  private[apirequest] def cachedOrRequest(url: String, output: Output): Validation[Throwable, JObject] = {
-    val value = cache.get(url) match {
+  private[apirequest] def cachedOrRequest(url: String,
+                                          body: Option[String],
+                                          output: Output): Validation[Throwable, JObject] = {
+    val key = cacheKey(url, body)
+    val value = cache.get(key) match {
       case Some(cachedResponse) => cachedResponse
-      case None => {
-        val json = api.perform(url).flatMap(output.parse)
-        cache.put(url, json)
+      case None =>
+        val json = api.perform(url, body).flatMap(output.parse)
+        cache.put(key, json)
         json
-      }
     }
     value.flatMap(output.extract).map(output.describeJson)
   }
@@ -159,4 +165,16 @@ object ApiRequestEnrichment {
         val data = fromJsonNode(node)
         ("schema" -> uri) ~ ("data" -> data \ "data")
     }
+
+  /**
+   * Creates an UUID based on url and optional body.
+   *
+   * @param url URL to query
+   * @param body optional request body
+   * @return UUID that identifies of the request.
+   */
+  def cacheKey(url: String, body: Option[String]): String = {
+    val contentKey = url + body.getOrElse("")
+    UUID.nameUUIDFromBytes(contentKey.getBytes).toString
+  }
 }

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/apirequest/HttpApi.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/apirequest/HttpApi.scala
@@ -19,12 +19,16 @@ package apirequest
 // Java
 import java.net.URLEncoder
 
+// json4s
+import org.json4s.DefaultFormats
+import org.json4s.jackson.Serialization
+
 // Scalaz
+import scalaz.Scalaz._
 import scalaz._
-import Scalaz._
 
 // This project
-import utils.HttpClient
+import com.snowplowanalytics.snowplow.enrich.common.utils.HttpClient
 
 /**
  * API client able to make HTTP requests
@@ -51,12 +55,12 @@ case class HttpApi(method: String, uri: String, timeout: Int, authentication: Au
    * Primary API method, taking kv-context derived from event (POJO and contexts),
    * generating request and sending it
    *
-   * @param client HTTP client to perform request
    * @param url URL to query
+   * @param body optional request body
    * @return self-describing JSON ready to be attached to event contexts
    */
-  def perform(url: String): Validation[Throwable, String] = {
-    val req = HttpClient.buildRequest(url, authUser = authUser, authPassword = authPassword, method)
+  def perform(url: String, body: Option[String] = None): Validation[Throwable, String] = {
+    val req = HttpClient.buildRequest(url, authUser = authUser, authPassword = authPassword, body, method)
     HttpClient.getBody(req)
   }
 
@@ -73,6 +77,19 @@ case class HttpApi(method: String, uri: String, timeout: Int, authentication: Au
     val url            = encodedContext.toList.foldLeft(uri)(replace)
     everythingMatched(url).option(url)
   }
+
+  /**
+   * Build request data body when the method supports this
+   *
+   * @param context key-value context
+   * @return Some body data if method supports body,
+   *         None if method does not support body
+   */
+  private[apirequest] def buildBody(context: Map[String, String]): Option[String] =
+    method match {
+      case "POST" | "PUT" => Some(Serialization.write(context)(DefaultFormats))
+      case "GET"          => None
+    }
 }
 
 object HttpApi {

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/apirequest/ApiRequestEnrichmentSpec.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/enrichments/registry/apirequest/ApiRequestEnrichmentSpec.scala
@@ -12,23 +12,33 @@
  */
 package com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.apirequest
 
+// Scalaz
+import org.json4s.jackson.JsonMethods
+import scalaz.Scalaz._
+
 // json4s
 import org.json4s._
 import org.json4s.jackson.parseJson
 
 // specs2
 import org.specs2.Specification
+import org.specs2.mock.Mockito
 import org.specs2.scalaz.ValidationMatchers
 
 // Iglu
+import com.snowplowanalytics.iglu.client.JsonSchemaPair
 import com.snowplowanalytics.iglu.client.SchemaKey
 
-class ApiRequestEnrichmentSpec extends Specification with ValidationMatchers {
+// Snowplow
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+
+class ApiRequestEnrichmentSpec extends Specification with ValidationMatchers with Mockito {
   def is = s2"""
   This is a specification to test the ApiRequestEnrichment configuration
-  Extract correct configuration                                $e1
-  Skip incorrect input (none of json or pojo) in configuration $e2
-  Skip incorrect input (both json and pojo) in configuration   $e3
+  Extract correct configuration for GET request and perform the request  $e1
+  Skip incorrect input (none of json or pojo) in configuration           $e2
+  Skip incorrect input (both json and pojo) in configuration             $e3
+  Extract correct configuration for POST request and perform the request $e4
   """"
 
   val SCHEMA_KEY =
@@ -38,7 +48,7 @@ class ApiRequestEnrichmentSpec extends Specification with ValidationMatchers {
     val inputs = List(
       Input("user", pojo = Some(PojoInput("user_id")), json = None),
       Input(
-        "user",
+        "userSession",
         pojo = None,
         json = Some(
           JsonInput("contexts", "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-*-*", "$.userId"))),
@@ -49,9 +59,32 @@ class ApiRequestEnrichmentSpec extends Specification with ValidationMatchers {
               "http://api.acme.com/users/{{client}}/{{user}}?format=json",
               1000,
               Authentication(Some(HttpBasic(Some("xxx"), None))))
+    val apiSpy = spy(api)
     val output = Output("iglu:com.acme/user/jsonschema/1-0-0", Some(JsonOutput("$.record")))
     val cache  = Cache(3000, 60)
-    val config = ApiRequestEnrichment(inputs, api, List(output), cache)
+    val config = ApiRequestEnrichment(inputs, apiSpy, List(output), cache)
+
+    val fakeEnrichedEvent = new EnrichedEvent {
+      app_id  = "some-fancy-app-id"
+      user_id = "some-fancy-user-id"
+    }
+
+    val clientSession: JsonSchemaPair = (
+      SchemaKey(vendor  = "com.snowplowanalytics.snowplow",
+                name    = "client_session",
+                format  = "jsonschema",
+                version = "1-0-1"),
+      JsonMethods.asJsonNode(parseJson(
+        """|{
+           |    "data": {
+           |        "userId": "some-fancy-user-session-id",
+           |        "sessionId": "42c8a55b-c0c2-4749-b9ac-09bb0d17d000",
+           |        "sessionIndex": 1,
+           |        "previousSessionId": null,
+           |        "storageMechanism": "COOKIE_1"
+           |    }
+           |}""".stripMargin))
+    )
 
     val configuration = parseJson(
       """|{
@@ -67,7 +100,7 @@ class ApiRequestEnrichmentSpec extends Specification with ValidationMatchers {
       |          }
       |        },
       |        {
-      |          "key": "user",
+      |          "key": "userSession",
       |          "json": {
       |            "field": "contexts",
       |            "schemaCriterion": "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-*-*",
@@ -108,6 +141,30 @@ class ApiRequestEnrichmentSpec extends Specification with ValidationMatchers {
       |  }""".stripMargin)
 
     ApiRequestEnrichmentConfig.parse(configuration, SCHEMA_KEY) must beSuccessful(config)
+
+    val user = parseJson(
+      """|{
+         |    "schema": "iglu:com.acme/user/jsonschema/1-0-0",
+         |    "data": {
+         |      "name": "Fancy User",
+         |      "company": "Acme"
+         |    }
+         |}
+      """.stripMargin)
+
+    apiSpy.perform(
+      url  = "http://api.acme.com/users/some-fancy-app-id/some-fancy-user-id?format=json",
+      body = None
+    ) returns """{"record": {"name": "Fancy User", "company": "Acme"}}""".success
+
+    val enrichedContextResult = config.lookup(
+      event           = fakeEnrichedEvent,
+      derivedContexts = List.empty,
+      customContexts  = List(clientSession),
+      unstructEvent   = List.empty
+    )
+
+    enrichedContextResult must beSuccessful(List(user))
   }
 
   def e2 = {
@@ -213,5 +270,124 @@ class ApiRequestEnrichmentSpec extends Specification with ValidationMatchers {
       |    }
       |  }""".stripMargin)
     ApiRequestEnrichmentConfig.parse(configuration, SCHEMA_KEY) must beFailing
+  }
+
+  def e4 = {
+    val inputs = List(
+      Input(key = "user", pojo = Some(PojoInput("user_id")), json = None),
+      Input(key  = "userSession", pojo = None, json = Some(
+        JsonInput("contexts", "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-*-*", "$.userId"))),
+      Input(key = "client", pojo = Some(PojoInput("app_id")), json = None)
+    )
+
+    val api = HttpApi(method = "POST", uri = "http://api.acme.com/users?format=json", timeout = 1000,
+      authentication = Authentication(Some(HttpBasic(Some("xxx"), None))))
+    val apiSpy = spy(api)
+    val output = Output(schema = "iglu:com.acme/user/jsonschema/1-0-0", json = Some(JsonOutput("$.record")))
+    val cache  = Cache(size = 3000, ttl = 60)
+    val config = ApiRequestEnrichment(inputs, apiSpy, List(output), cache)
+
+    val fakeEnrichedEvent = new EnrichedEvent {
+      app_id  = "some-fancy-app-id"
+      user_id = "some-fancy-user-id"
+    }
+
+    val clientSession: JsonSchemaPair = (
+      SchemaKey(vendor  = "com.snowplowanalytics.snowplow",
+                name    = "client_session",
+                format  = "jsonschema",
+                version = "1-0-1"),
+      JsonMethods.asJsonNode(parseJson(
+        """|{
+           |    "data": {
+           |        "userId": "some-fancy-user-session-id",
+           |        "sessionId": "42c8a55b-c0c2-4749-b9ac-09bb0d17d000",
+           |        "sessionIndex": 1,
+           |        "previousSessionId": null,
+           |        "storageMechanism": "COOKIE_1"
+           |    }
+           |}""".stripMargin))
+    )
+
+    val configuration = parseJson(
+      """|{
+         |    "vendor": "com.snowplowanalytics.snowplow.enrichments",
+         |    "name": "api_request_enrichment_config",
+         |    "enabled": true,
+         |    "parameters": {
+         |      "inputs": [
+         |        {
+         |          "key": "user",
+         |          "pojo": {
+         |            "field": "user_id"
+         |          }
+         |        },
+         |        {
+         |          "key": "userSession",
+         |          "json": {
+         |            "field": "contexts",
+         |            "schemaCriterion": "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-*-*",
+         |            "jsonPath": "$.userId"
+         |          }
+         |        },
+         |        {
+         |          "key": "client",
+         |          "pojo": {
+         |            "field": "app_id"
+         |          }
+         |        }
+         |      ],
+         |      "api": {
+         |        "http": {
+         |          "method": "POST",
+         |          "uri": "http://api.acme.com/users?format=json",
+         |          "timeout": 1000,
+         |          "authentication": {
+         |            "httpBasic": {
+         |              "username": "xxx",
+         |              "password": null
+         |            }
+         |          }
+         |        }
+         |      },
+         |      "outputs": [{
+         |        "schema": "iglu:com.acme/user/jsonschema/1-0-0",
+         |        "json": {
+         |          "jsonPath": "$.record"
+         |        }
+         |      }],
+         |      "cache": {
+         |        "size": 3000,
+         |        "ttl": 60
+         |      }
+         |    }
+         |  }""".stripMargin)
+
+    ApiRequestEnrichmentConfig.parse(configuration, SCHEMA_KEY) must beSuccessful(config)
+
+    val user = parseJson(
+      """|{
+         |    "schema": "iglu:com.acme/user/jsonschema/1-0-0",
+         |    "data": {
+         |      "name": "Fancy User",
+         |      "company": "Acme"
+         |    }
+         |}
+      """.stripMargin)
+
+    apiSpy.perform(
+      url = "http://api.acme.com/users?format=json",
+      body = Some(
+        """{"client":"some-fancy-app-id","user":"some-fancy-user-id","userSession":"some-fancy-user-session-id"}""")
+    ) returns """{"record": {"name": "Fancy User", "company": "Acme"}}""".success
+
+    val enrichedContextResult = config.lookup(
+      event           = fakeEnrichedEvent,
+      derivedContexts = List.empty,
+      customContexts  = List(clientSession),
+      unstructEvent   = List.empty
+    )
+
+    enrichedContextResult must beSuccessful(List(user))
   }
 }


### PR DESCRIPTION
This PR supports POST requests with body in the API enrichment described by issue #3857. Also in-memory cache key was changed to an UUID created from URL + Request Body.
