### PR TITLE
Allows the DNT cookie's config value to be a regex.

### DIFF
--- a/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRoute.scala
+++ b/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRoute.scala
@@ -136,7 +136,7 @@ trait CollectorRoute {
   def doNotTrack(configCookie: Option[HttpCookie]): Directive1[Boolean] =
     cookieIfWanted(configCookie.map(_.name)).map { c =>
       (c, configCookie) match {
-        case (Some(actual), Some(config)) => actual.value == config.value
+        case (Some(actual), Some(config)) => config.value.r.pattern.matcher(actual.value).matches()
         case _ => false
       }
     }

--- a/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRoute.scala
+++ b/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRoute.scala
@@ -18,6 +18,7 @@ import akka.http.scaladsl.model.{ContentType, HttpResponse, StatusCode, StatusCo
 import akka.http.scaladsl.model.headers.{HttpCookie, HttpCookiePair}
 import akka.http.scaladsl.server.{Directive1, Route}
 import akka.http.scaladsl.server.Directives._
+import com.snowplowanalytics.snowplow.collectors.scalastream.model.DntCookieMatcher
 
 import monitoring.BeanRegistry
 
@@ -131,12 +132,12 @@ trait CollectorRoute {
 
   /**
    * Directive to filter requests which contain a do not track cookie
-   * @param configCookie the configured do not track cookie to check against
+   * @param cookieMatcher the configured do not track cookie to check against
    */
-  def doNotTrack(configCookie: Option[HttpCookie]): Directive1[Boolean] =
-    cookieIfWanted(configCookie.map(_.name)).map { c =>
-      (c, configCookie) match {
-        case (Some(actual), Some(config)) => config.value.r.pattern.matcher(actual.value).matches()
+  def doNotTrack(cookieMatcher: Option[DntCookieMatcher]): Directive1[Boolean] =
+    cookieIfWanted(cookieMatcher.map(_.name)).map { c =>
+      (c, cookieMatcher) match {
+        case (Some(actual), Some(config)) => config.matches(actual)
         case _ => false
       }
     }

--- a/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
+++ b/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
@@ -54,7 +54,7 @@ trait Service {
     contentType: Option[ContentType] = None
   ): (HttpResponse, List[Array[Byte]])
   def cookieName: Option[String]
-  def doNotTrackCookie: Option[HttpCookie]
+  def doNotTrackCookie: Option[DntCookieMatcher]
 }
 
 object CollectorService {

--- a/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
+++ b/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
@@ -59,9 +59,7 @@ package model {
   )
   final case class DntCookieMatcher(name: String, value: String) {
     private val pattern = value.r.pattern
-    def matches(httpCookiePair: HttpCookiePair): Boolean ={
-      pattern.matcher(httpCookiePair.value).matches()
-    }
+    def matches(httpCookiePair: HttpCookiePair): Boolean = pattern.matcher(httpCookiePair.value).matches()
   }
   final case class CookieBounceConfig(
     enabled: Boolean,

--- a/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
+++ b/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
@@ -17,6 +17,7 @@ package com.snowplowanalytics.snowplow.collectors.scalastream
 import scala.concurrent.duration.FiniteDuration
 
 import akka.http.scaladsl.model.headers.HttpCookie
+import akka.http.scaladsl.model.headers.HttpCookiePair
 
 import sinks.Sink
 
@@ -56,6 +57,12 @@ package model {
     name: String,
     value: String
   )
+  final case class DntCookieMatcher(name: String, value: String) {
+    private val pattern = value.r.pattern
+    def matches(httpCookiePair: HttpCookiePair): Boolean ={
+      pattern.matcher(httpCookiePair.value).matches()
+    }
+  }
   final case class CookieBounceConfig(
     enabled: Boolean,
     name: String,
@@ -125,7 +132,7 @@ package model {
     val cookieConfig = if (cookie.enabled) Some(cookie) else None
     val doNotTrackHttpCookie =
       if (doNotTrackCookie.enabled)
-        Some(HttpCookie(name = doNotTrackCookie.name, value = doNotTrackCookie.value))
+        Some(DntCookieMatcher(name = doNotTrackCookie.name, value = doNotTrackCookie.value))
       else
         None
 

--- a/2-collectors/scala-stream-collector/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRouteSpec.scala
+++ b/2-collectors/scala-stream-collector/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRouteSpec.scala
@@ -14,6 +14,10 @@
  */
 package com.snowplowanalytics.snowplow.collectors.scalastream
 
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.testkit.Specs2RouteTest
+import akka.http.scaladsl.server.Directives._
 import org.specs2.mutable.Specification
 
 class CollectorRouteSpec extends Specification with Specs2RouteTest {

--- a/2-collectors/scala-stream-collector/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRouteSpec.scala
+++ b/2-collectors/scala-stream-collector/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRouteSpec.scala
@@ -14,10 +14,6 @@
  */
 package com.snowplowanalytics.snowplow.collectors.scalastream
 
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers._
-import akka.http.scaladsl.testkit.Specs2RouteTest
-import akka.http.scaladsl.server.Directives._
 import org.specs2.mutable.Specification
 
 class CollectorRouteSpec extends Specification with Specs2RouteTest {
@@ -158,6 +154,14 @@ class CollectorRouteSpec extends Specification with Specs2RouteTest {
           } ~> check {
             responseAs[String] shouldEqual "true"
           }
+      }
+      "return true if there is a properly-valued dnt cookie that matches a regex value" in {
+        Get() ~> Cookie("abc" -> s"deleted-${System.currentTimeMillis()}") ~>
+          route.doNotTrack(Some(HttpCookie(name = "abc", value = "deleted-[0-9]+"))) { dnt =>
+            complete(dnt.toString)
+          } ~> check {
+          responseAs[String] shouldEqual "true"
+        }
       }
     }
   }

--- a/2-collectors/scala-stream-collector/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRouteSpec.scala
+++ b/2-collectors/scala-stream-collector/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRouteSpec.scala
@@ -18,6 +18,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.testkit.Specs2RouteTest
 import akka.http.scaladsl.server.Directives._
+import com.snowplowanalytics.snowplow.collectors.scalastream.model.DntCookieMatcher
 import org.specs2.mutable.Specification
 
 class CollectorRouteSpec extends Specification with Specs2RouteTest {
@@ -42,7 +43,7 @@ class CollectorRouteSpec extends Specification with Specs2RouteTest {
         contentType: Option[ContentType] = None
       ): (HttpResponse, List[Array[Byte]]) = (HttpResponse(200, entity = s"cookie"), List.empty)
       def cookieName: Option[String] = Some("name")
-      def doNotTrackCookie: Option[HttpCookie] = None
+      def doNotTrackCookie: Option[DntCookieMatcher] = None
     }
   }
 
@@ -145,7 +146,7 @@ class CollectorRouteSpec extends Specification with Specs2RouteTest {
       }
       "return false if the dnt cookie doesn't have the same value compared to configuration" in {
         Get() ~> Cookie("abc" -> "123") ~>
-          route.doNotTrack(Some(HttpCookie(name = "abc", value = "345"))) { dnt =>
+          route.doNotTrack(Some(DntCookieMatcher(name = "abc", value = "345"))) { dnt =>
             complete(dnt.toString)
           } ~> check {
             responseAs[String] shouldEqual "false"
@@ -153,7 +154,7 @@ class CollectorRouteSpec extends Specification with Specs2RouteTest {
       }
       "return true if there is a properly-valued dnt cookie" in {
         Get() ~> Cookie("abc" -> "123") ~>
-          route.doNotTrack(Some(HttpCookie(name = "abc", value = "123"))) { dnt =>
+          route.doNotTrack(Some(DntCookieMatcher(name = "abc", value = "123"))) { dnt =>
             complete(dnt.toString)
           } ~> check {
             responseAs[String] shouldEqual "true"
@@ -161,7 +162,7 @@ class CollectorRouteSpec extends Specification with Specs2RouteTest {
       }
       "return true if there is a properly-valued dnt cookie that matches a regex value" in {
         Get() ~> Cookie("abc" -> s"deleted-${System.currentTimeMillis()}") ~>
-          route.doNotTrack(Some(HttpCookie(name = "abc", value = "deleted-[0-9]+"))) { dnt =>
+          route.doNotTrack(Some(DntCookieMatcher(name = "abc", value = "deleted-[0-9]+"))) { dnt =>
             complete(dnt.toString)
           } ~> check {
           responseAs[String] shouldEqual "true"

--- a/2-collectors/scala-stream-collector/examples/config.hocon.sample
+++ b/2-collectors/scala-stream-collector/examples/config.hocon.sample
@@ -55,7 +55,8 @@ collector {
   # If you have a do not track cookie in place, the Scala Stream Collector can respect it by
   # completely bypassing the processing of an incoming request carrying this cookie, the collector
   # will simply reply by a 200 saying "do not track".
-  # The cookie name and value must match the configuration below.
+  # The cookie name and value must match the configuration below, where the names of the cookies must
+  # match entirely and the value could be a regular expression.
   doNotTrackCookie {
     enabled = false
     name = {{doNotTrackCookieName}}


### PR DESCRIPTION
This enables us to have variable parts of a DNT cookie. As an example in the tests, storing the information when a DNT cookie was added  into the cooke, allows the collector not to track events.