### PR TITLE
Patch: com.marketo

### DIFF
--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/MarketoAdapter.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/MarketoAdapter.scala
@@ -55,7 +55,7 @@ object MarketoAdapter extends Adapter {
 
   // Schemas for reverse-engineering a Snowplow unstructured event
   private val EventSchemaMap = Map(
-    "event" -> SchemaKey("com.marketo", "event", "jsonschema", "1-0-0").toSchemaUri
+    "event" -> SchemaKey("com.marketo", "event", "jsonschema", "2-0-0").toSchemaUri
   )
 
   // Datetime format used by Marketo
@@ -93,6 +93,8 @@ object MarketoAdapter extends Adapter {
           ("updated_at", JString(JU.toJsonSchemaDateTime(value, MarketoDateTimeFormat)))
         case ("datetime", JString(value)) =>
           ("datetime", JString(JU.toJsonSchemaDateTime(value, MarketoDateTimeFormat)))
+        case ("last_interesting_moment_date", JString(value)) =>
+          ("last_interesting_moment_date", JString(JU.toJsonSchemaDateTime(value, MarketoDateTimeFormat)))
       }
       // The payload doesn't contain a "type" field so we're constraining the eventType to be of type "event"
       eventType = Some("event")

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/MarketoAdapterSpec.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/MarketoAdapterSpec.scala
@@ -61,7 +61,7 @@ class MarketoAdapterSpec extends Specification with DataTables with ValidationMa
 
   def e1 = {
     val bodyStr =
-      """{"name": "webhook for A", "step": 6, "campaign": {"id": 160, "name": "avengers assemble"}, "lead": {"acquisition_date": "2010-11-11 11:11:11", "black_listed": false, "first_name": "the hulk", "updated_at": "", "created_at": "2018-06-16 11:23:58"}, "company": {"name": "iron man", "notes": "the something dog leapt over the lazy fox"}, "campaign": {"id": 987, "name": "triggered event"}, "datetime": "2018-03-07 14:28:16"}"""
+      """{"name": "webhook for A", "step": 6, "campaign": {"id": 160, "name": "avengers assemble"}, "lead": {"acquisition_date": "2010-11-11 11:11:11", "black_listed": false, "first_name": "the hulk", "updated_at": "", "created_at": "2018-06-16 11:23:58", "last_interesting_moment_date": "2018-09-26 20:26:40"}, "company": {"name": "iron man", "notes": "the something dog leapt over the lazy fox"}, "campaign": {"id": 987, "name": "triggered event"}, "datetime": "2018-03-07 14:28:16"}"""
     val payload = CollectorPayload(Shared.api, Nil, ContentType.some, bodyStr.some, Shared.cljSource, Shared.context)
     val expected = NonEmptyList(
       RawEvent(
@@ -70,7 +70,7 @@ class MarketoAdapterSpec extends Specification with DataTables with ValidationMa
           "tv"    -> "com.marketo-v1",
           "e"     -> "ue",
           "p"     -> "srv",
-          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.marketo/event/jsonschema/1-0-0","data":{"name":"webhook for A","step":6,"campaign":{"id":160,"name":"avengers assemble"},"lead":{"acquisition_date":"2010-11-11T11:11:11.000Z","black_listed":false,"first_name":"the hulk","updated_at":"","created_at":"2018-06-16T11:23:58.000Z"},"company":{"name":"iron man","notes":"the something dog leapt over the lazy fox"},"campaign":{"id":987,"name":"triggered event"},"datetime":"2018-03-07T14:28:16.000Z"}}}"""
+          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.marketo/event/jsonschema/2-0-0","data":{"name":"webhook for A","step":6,"campaign":{"id":160,"name":"avengers assemble"},"lead":{"acquisition_date":"2010-11-11T11:11:11.000Z","black_listed":false,"first_name":"the hulk","updated_at":"","created_at":"2018-06-16T11:23:58.000Z","last_interesting_moment_date":"2018-09-26T20:26:40.000Z"},"company":{"name":"iron man","notes":"the something dog leapt over the lazy fox"},"campaign":{"id":987,"name":"triggered event"},"datetime":"2018-03-07T14:28:16.000Z"}}}"""
         ),
         ContentType.some,
         Shared.cljSource,


### PR DESCRIPTION
A field (`last_interesting_moment_date`) previously thought to be of type `date` is actually `date-time`. The field has now been added to be formatted correctly.

Schema also updated with PR [-->](https://github.com/snowplow/iglu-central/pull/850)