### PR TITLE
Add a configurable Access-Control-Max-Age header

### DIFF
--- a/2-collectors/scala-stream-collector/config.hocon.sample
+++ b/2-collectors/scala-stream-collector/config.hocon.sample
@@ -1,0 +1,165 @@
+# Copyright (c) 2013-2016 Snowplow Analytics Ltd. All rights reserved.
+#
+# This program is licensed to you under the Apache License Version 2.0, and
+# you may not use this file except in compliance with the Apache License
+# Version 2.0.  You may obtain a copy of the Apache License Version 2.0 at
+# http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License Version 2.0 is distributed on an "AS
+# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the Apache License Version 2.0 for the specific language
+# governing permissions and limitations there under.
+
+# This file (application.conf.example) contains a template with
+# configuration options for the Scala Stream Collector.
+#
+# To use, copy this to 'application.conf' and modify the configuration options.
+
+# 'collector' contains configuration options for the main Scala collector.
+collector {
+  # The collector runs as a web service specified on the following
+  # interface and port.
+  interface = "0.0.0.0"
+  port = 8000
+  accessControlMaxAge = -1  
+
+  # Production mode disables additional services helpful for configuring and
+  # initializing the collector, such as a path '/dump' to view all
+  # records stored in the current stream.
+  production = false
+
+  # Configure the P3P policy header.
+  p3p {
+    policyref = "/w3c/p3p.xml"
+    CP = "NOI DSP COR NID PSA OUR IND COM NAV STA"
+  }
+
+  # The collector returns a cookie to clients for user identification
+  # with the following domain and expiration.
+  cookie {
+    enabled = true
+    expiration = "365 days" # e.g. "365 days"
+    # Network cookie name
+    name = x
+    # The domain is optional and will make the cookie accessible to other
+    # applications on the domain. Comment out this line to tie cookies to
+    # the collector's full domain
+    domain = "localhost"
+  }
+
+  # The collector has a configurable sink for storing data in
+  # different formats for the enrichment process.
+  sink {
+    # Sinks currently supported are:
+    # 'kinesis' for writing Thrift-serialized records to a Kinesis stream
+    # 'kafka' for writing Thrift-serialized records to kafka
+    # 'gcppubsub' for writing Thrift-serialized records to Google Pub/Sub
+    # 'stdout' for writing Base64-encoded Thrift-serialized records to stdout
+    #    Recommended settings for 'stdout' so each line printed to stdout
+    #    is a serialized record are:
+    #      1. Setting 'akka.loglevel = OFF' and 'akka.loggers = []'
+    #         to disable all logging.
+    #      2. Using 'sbt assembly' and 'java -jar ...' to disable
+    #         sbt logging.
+    enabled = "gcpubsub"
+
+    kinesis {
+      thread-pool-size: 10 # Thread pool size for Kinesis API requests
+
+      # The following are used to authenticate for the Amazon Kinesis sink.
+      #
+      # If both are set to 'default', the default provider chain is used
+      # (see http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html)
+      #
+      # If both are set to 'iam', use AWS IAM Roles to provision credentials.
+      #
+      # If both are set to 'env', use environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+      aws {
+        access-key: "iam"
+        secret-key: "iam"
+      }
+
+      # Data will be stored in the following stream.
+      stream {
+        region: "{{collectorSinkKinesisStreamRegion}}"
+        good: "{{collectorKinesisStreamGoodName}}"
+        bad: "{{collectorKinesisStreamBadName}}"
+      }
+
+      # Minimum and maximum backoff periods
+      backoffPolicy: {
+        minBackoff: 100
+        maxBackoff: 200
+      }
+    }
+
+    kafka {
+      brokers: "{{collectorKafkaBrokers}}"
+
+      # Data will be stored in the following topics
+      topic {
+        good: "{{collectorKafkaTopicGoodName}}"
+        bad: "{{collectorKafkaTopicBadName}}"
+      }
+    }
+
+    gcpubsub {
+      # this is the project ID inside of which your collector will be running
+      googleAuthPath: "snowflake-test.json"
+      googleProjectId: "snowflake-test"
+
+      # Data will be stored in the following topics (they must have been created ahead-of-time)
+      topic {
+        good: "snowplow-collector-good"
+        bad: "snowplow-collector-bad"
+      }
+
+      # Minimum and maximum backoff periods and retry multiplier
+      retryPolicy: {
+        minBackoff: 100
+        maxBackoff: 400
+        retryDelayMultiplier: 2.0
+        totalTimeOut: 10000
+        initialRpcTimeout: 1000
+        maxRpcTimeout: 1000
+      }
+    }
+
+    # Incoming events are stored in a buffer before being sent to Kinesis/Kafka/PubSub.
+    # The buffer is emptied whenever:
+    # - the number of stored records reaches record-limit or
+    # - the combined size of the stored records reaches byte-limit or
+    # - the time in milliseconds since the buffer was last emptied reaches time-limit
+    buffer {
+      byte-limit: 100000
+      record-limit: 1 # Not supported by Kafka; will be ignored
+      time-limit: 60000
+    }
+  }
+}
+
+# Akka has a variety of possible configuration options defined at
+# http://doc.akka.io/docs/akka/2.2.3/general/configuration.html.
+akka {
+  loglevel = DEBUG # 'OFF' for no logging, 'DEBUG' for all logging.
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+}
+
+# spray-can is the server the Stream collector uses and has configurable
+# options defined at
+# https://github.com/spray/spray/blob/master/spray-can/src/main/resources/reference.conf
+spray.can.server {
+  # To obtain the hostname in the collector, the 'remote-address' header
+  # should be set. By default, this is disabled, and enabling it
+  # adds the 'Remote-Address' header to every request automatically.
+  remote-address-header = on
+
+  uri-parsing-mode = relaxed
+  raw-request-uri-header = on
+
+  # Define the maximum request length (the default is 2048)
+  parsing {
+    max-uri-length = 32768
+  }
+}

--- a/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
+++ b/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
@@ -140,7 +140,8 @@ class CollectorService(
       .withHeaders(List(
         accessControlAllowOriginHeader(request),
         `Access-Control-Allow-Credentials`(true),
-        `Access-Control-Allow-Headers`("Content-Type")
+        `Access-Control-Allow-Headers`("Content-Type"),
+        `Access-Control-Max-Age`(config.accessControlMaxAge)
       ))
 
   override def flashCrossDomainPolicy: HttpResponse =

--- a/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
+++ b/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
@@ -113,6 +113,7 @@ package model {
   final case class CollectorConfig(
     interface: String,
     port: Int,
+    accessControlMaxAge: Int,
     p3p: P3PConfig,
     crossDomain: CrossDomainConfig,
     cookie: CookieConfig,


### PR DESCRIPTION
This adds an additional header to allow caching of the OPTIONS response from the collector see #3904 

@BenFradet Where do you think I should put this property in the configuration hocon? I'm not sure that putting it at the root of the collector config is the best option.