### PR TITLE
Add: com.hubspot (closes #3282)

### DIFF
--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/AdapterRegistry.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/AdapterRegistry.scala
@@ -55,6 +55,7 @@ object AdapterRegistry {
     val UrbanAirship    = "com.urbanairship.connect"
     val Marketo         = "com.marketo"
     val Vero            = "com.getvero"
+    val HubSpot         = "com.hubspot"
   }
 
   /**
@@ -91,6 +92,7 @@ object AdapterRegistry {
       case (Vendor.UrbanAirship, "v1")          => UrbanAirshipAdapter.toRawEvents(payload)
       case (Vendor.Marketo, "v1")               => MarketoAdapter.toRawEvents(payload)
       case (Vendor.Vero, "v1")                  => VeroAdapter.toRawEvents(payload)
+      case (Vendor.HubSpot, "v1")               => HubSpotAdapter.toRawEvents(payload)
       case _ =>
         s"Payload with vendor ${payload.api.vendor} and version ${payload.api.version} not supported by this version of Scala Common Enrich".failNel
     }

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/HubSpotAdapter.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/adapters/registry/HubSpotAdapter.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2014-2018 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics
+package snowplow
+package enrich
+package common
+package adapters
+package registry
+
+// Jackson
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.core.JsonParseException
+
+// Scalaz
+import scalaz._
+import Scalaz._
+
+// json4s
+import org.json4s._
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+import org.json4s.scalaz.JsonScalaz._
+
+// Iglu
+import iglu.client.{Resolver, SchemaKey}
+import iglu.client.validation.ValidatableJsonMethods._
+
+// Joda Time
+import org.joda.time.DateTime
+
+// This project
+import loaders.CollectorPayload
+import utils.{JsonUtils => JU}
+
+/**
+ * Transforms a collector payload which conforms to
+ * a known version of the HubSpot webhook subscription
+ * into raw events.
+ */
+object HubSpotAdapter extends Adapter {
+
+  // Vendor name for Failure Message
+  private val VendorName = "HubSpot"
+
+  // Tracker version for a HubSpot webhook
+  private val TrackerVersion = "com.hubspot-v1"
+
+  // Expected content type for a request body
+  private val ContentType = "application/json"
+
+  // Event-Schema Map for reverse-engineering a Snowplow unstructured event
+  private val EventSchemaMap = Map(
+    "contact.creation"       -> SchemaKey("com.hubspot", "contact_creation", "jsonschema", "1-0-0").toSchemaUri,
+    "contact.deletion"       -> SchemaKey("com.hubspot", "contact_deletion", "jsonschema", "1-0-0").toSchemaUri,
+    "contact.propertyChange" -> SchemaKey("com.hubspot", "contact_change", "jsonschema", "1-0-0").toSchemaUri,
+    "company.creation"       -> SchemaKey("com.hubspot", "company_creation", "jsonschema", "1-0-0").toSchemaUri,
+    "company.deletion"       -> SchemaKey("com.hubspot", "company_deletion", "jsonschema", "1-0-0").toSchemaUri,
+    "company.propertyChange" -> SchemaKey("com.hubspot", "company_change", "jsonschema", "1-0-0").toSchemaUri,
+    "deal.creation"          -> SchemaKey("com.hubspot", "deal_creation", "jsonschema", "1-0-0").toSchemaUri,
+    "deal.deletion"          -> SchemaKey("com.hubspot", "deal_deletion", "jsonschema", "1-0-0").toSchemaUri,
+    "deal.propertyChange"    -> SchemaKey("com.hubspot", "deal_change", "jsonschema", "1-0-0").toSchemaUri
+  )
+
+  /**
+   * Converts a CollectorPayload instance into raw events.
+   * A HubSpot Tracking payload can contain many events in one.
+   * We expect the type parameter to be 1 of 9 options otherwise
+   * we have an unsupported event type.
+   *
+   * @param payload The CollectorPaylod containing one or more
+   *        raw events as collected by a Snowplow collector
+   * @param resolver (implicit) The Iglu resolver used for
+   *        schema lookup and validation. Not used
+   * @return a Validation boxing either a NEL of RawEvents on
+   *         Success, or a NEL of Failure Strings
+   */
+  def toRawEvents(payload: CollectorPayload)(implicit resolver: Resolver): ValidatedRawEvents =
+    (payload.body, payload.contentType) match {
+      case (None, _) => s"Request body is empty: no ${VendorName} events to process".failNel
+      case (_, None) =>
+        s"Request body provided but content type empty, expected ${ContentType} for ${VendorName}".failNel
+      case (_, Some(ct)) if ct != ContentType =>
+        s"Content type of ${ct} provided, expected ${ContentType} for ${VendorName}".failNel
+      case (Some(body), _) => {
+
+        payloadBodyToEvents(body) match {
+          case Failure(str) => str.failNel
+          case Success(list) => {
+
+            // Create our list of Validated RawEvents
+            val rawEventsList: List[Validated[RawEvent]] =
+              for {
+                (event, index) <- list.zipWithIndex
+              } yield {
+
+                val eventType: Option[String] = (event \ "subscriptionType").extractOpt[String]
+                for {
+                  schema <- lookupSchema(eventType, VendorName, index, EventSchemaMap)
+                } yield {
+
+                  val formattedEvent = reformatParameters(event)
+                  val qsParams       = toMap(payload.querystring)
+                  RawEvent(
+                    api         = payload.api,
+                    parameters  = toUnstructEventParams(TrackerVersion, qsParams, schema, formattedEvent, "srv"),
+                    contentType = payload.contentType,
+                    source      = payload.source,
+                    context     = payload.context
+                  )
+                }
+              }
+
+            // Processes the List for Failures and Successes and returns ValidatedRawEvents
+            rawEventsListProcessor(rawEventsList)
+          }
+        }
+      }
+    }
+
+  /**
+   * Returns a list of JValue events from the
+   * HubSpot payload
+   *
+   * @param body The payload body from the HubSpot
+   *        event
+   * @return either a Successful List of JValue JSONs
+   *         or a Failure String
+   */
+  private[registry] def payloadBodyToEvents(body: String): Validation[String, List[JValue]] =
+    try {
+      val parsed = parse(body)
+      parsed match {
+        case JArray(list) => list.success
+        case _            => s"Could not resolve ${VendorName} payload into a JSON array of events".fail
+      }
+    } catch {
+      case e: JsonParseException => {
+        val exception = JU.stripInstanceEtc(e.toString).orNull
+        s"${VendorName} payload failed to parse into JSON: [${exception}]".fail
+      }
+    }
+
+  /**
+   * Returns an updated HubSpot event JSON where
+   * the "subscriptionType" field is removed
+   * and "occurredAt" fields' values have been converted
+   *
+   * @param json The event JSON which we need to
+   *        update values for
+   * @return the updated JSON with updated fields and values
+   */
+  def reformatParameters(json: JValue): JValue = {
+
+    def toStringField(value: Long): JString = {
+      val dt: DateTime = new DateTime(value)
+      JString(JsonSchemaDateTimeFormat.print(dt))
+    }
+
+    json removeField {
+      case ("subscriptionType", JString(s)) => true
+      case _                                => false
+    } transformField {
+      case ("occurredAt", JInt(value)) => ("occurredAt", toStringField(value.toLong))
+    }
+  }
+}

--- a/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/HubSpotAdapterSpec.scala
+++ b/3-enrich/scala-common-enrich/src/test/scala/com.snowplowanalytics.snowplow.enrich.common/adapters/registry/HubSpotAdapterSpec.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2012-2018 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.enrich.common
+package adapters
+package registry
+
+// Joda-Time
+import org.joda.time.DateTime
+
+// Scalaz
+import scalaz._
+import Scalaz._
+
+// json4s
+import org.json4s._
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+import org.json4s.scalaz.JsonScalaz._
+
+// Snowplow
+import loaders.{CollectorApi, CollectorContext, CollectorPayload, CollectorSource}
+import utils.ConversionUtils
+import SpecHelpers._
+
+// Specs2
+import org.specs2.{ScalaCheck, Specification}
+import org.specs2.matcher.DataTables
+import org.specs2.scalaz.ValidationMatchers
+
+class HubSpotAdapterSpec extends Specification with DataTables with ValidationMatchers with ScalaCheck {
+  def is = s2"""
+  This is a specification to test the HubSpotAdapter functionality
+  payloadBodyToEvents must return a Success list of event JSON's from a valid payload body           $e1
+  payloadBodyToEvents must return a Failure Nel for an invalid payload body being passed             $e2
+  toRawEvents must return a Success Nel if all events are successful                                 $e3
+  toRawEvents must return a Failure Nel if any of the events where not successes                     $e4
+  toRawEvents must return a Nel Failure if the request body is missing                               $e5
+  toRawEvents must return a Nel Failure if the content type is missing                               $e6
+  toRawEvents must return a Nel Failure if the content type is incorrect                             $e7
+  """
+
+  implicit val resolver = SpecHelpers.IgluResolver
+
+  object Shared {
+    val api       = CollectorApi("com.hubspot", "v1")
+    val cljSource = CollectorSource("clj-tomcat", "UTF-8", None)
+    val context = CollectorContext(DateTime.parse("2013-08-29T00:18:48.000+00:00").some,
+                                   "37.157.33.123".some,
+                                   None,
+                                   None,
+                                   Nil,
+                                   None)
+  }
+
+  val ContentType = "application/json"
+
+  def e1 = {
+    val bodyStr  = """[{"subscriptionType":"company.change","eventId":16}]"""
+    val expected = List(JObject(List(("subscriptionType", JString("company.change")), ("eventId", JInt(16)))))
+    HubSpotAdapter.payloadBodyToEvents(bodyStr) must beSuccessful(expected)
+  }
+
+  def e2 =
+    "SPEC NAME"                  || "INPUT"                   | "EXPECTED OUTPUT" |
+      "Failure, parse exception" !! """{"something:"some"}""" ! """HubSpot payload failed to parse into JSON: [com.fasterxml.jackson.core.JsonParseException: Unexpected character ('s' (code 115)): was expecting a colon to separate field name and value at [Source: (String)"{"something:"some"}"; line: 1, column: 15]]""" |> {
+      (_, input, expected) =>
+        HubSpotAdapter.payloadBodyToEvents(input) must beFailing(expected)
+    }
+
+  def e3 = {
+    val bodyStr =
+      """[{"eventId":1,"subscriptionId":25458,"portalId":4737818,"occurredAt":1539145399845,"subscriptionType":"contact.creation","attemptNumber":0,"objectId":123,"changeSource":"CRM","changeFlag":"NEW","appId":177698}]"""
+    val payload = CollectorPayload(Shared.api, Nil, ContentType.some, bodyStr.some, Shared.cljSource, Shared.context)
+    val expected = NonEmptyList(
+      RawEvent(
+        Shared.api,
+        Map(
+          "tv"    -> "com.hubspot-v1",
+          "e"     -> "ue",
+          "p"     -> "srv",
+          "ue_pr" -> """{"schema":"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0","data":{"schema":"iglu:com.hubspot/contact_creation/jsonschema/1-0-0","data":{"eventId":1,"subscriptionId":25458,"portalId":4737818,"occurredAt":"2018-10-10T04:23:19.845Z","attemptNumber":0,"objectId":123,"changeSource":"CRM","changeFlag":"NEW","appId":177698}}}"""
+        ),
+        ContentType.some,
+        Shared.cljSource,
+        Shared.context
+      ))
+    HubSpotAdapter.toRawEvents(payload) must beSuccessful(expected)
+  }
+
+  def e4 = {
+    val bodyStr =
+      """[{"eventId":1,"subscriptionId":25458,"portalId":4737818,"occurredAt":1539145399845,"subscriptionType":"contact","attemptNumber":0,"objectId":123,"changeSource":"CRM","changeFlag":"NEW","appId":177698}]"""
+    val payload  = CollectorPayload(Shared.api, Nil, ContentType.some, bodyStr.some, Shared.cljSource, Shared.context)
+    val expected = "HubSpot event at index [0] failed: type parameter [contact] not recognized"
+    HubSpotAdapter.toRawEvents(payload) must beFailing(NonEmptyList(expected))
+  }
+
+  def e5 = {
+    val payload = CollectorPayload(Shared.api, Nil, ContentType.some, None, Shared.cljSource, Shared.context)
+    HubSpotAdapter.toRawEvents(payload) must beFailing(
+      NonEmptyList("Request body is empty: no HubSpot events to process"))
+  }
+
+  def e6 = {
+    val payload = CollectorPayload(Shared.api, Nil, None, "stub".some, Shared.cljSource, Shared.context)
+    HubSpotAdapter.toRawEvents(payload) must beFailing(
+      NonEmptyList("Request body provided but content type empty, expected application/json for HubSpot"))
+  }
+
+  def e7 = {
+    val payload = CollectorPayload(Shared.api,
+                                   Nil,
+                                   "application/x-www-form-urlencoded".some,
+                                   "stub".some,
+                                   Shared.cljSource,
+                                   Shared.context)
+    HubSpotAdapter.toRawEvents(payload) must beFailing(
+      NonEmptyList("Content type of application/x-www-form-urlencoded provided, expected application/json for HubSpot"))
+  }
+}


### PR DESCRIPTION
Adapter for HubSpot that will formats the 9 webhook subscription types. Only conversion needed is for the field `occuredAt` from epoch in milliseconds to timestamp and dropping the `subscriptionType` field.
Schemas can be found [here](https://github.com/snowplow/iglu-central/pull/851).
