### PR TITLE
Scala stream collector: Extend config to override kafka producer config

### DIFF
--- a/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
+++ b/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
@@ -99,7 +99,11 @@ package model {
     googleProjectId: String,
     backoffPolicy: GooglePubSubBackoffPolicyConfig
   ) extends SinkConfig
-  final case class Kafka(brokers: String, retries: Int) extends SinkConfig
+  final case class Kafka(
+    brokers: String,
+    retries: Int,
+    producerConf: Option[Map[String,String]]
+  ) extends SinkConfig
   final case class Nsq(host: String, port: Int) extends SinkConfig
   case object Stdout extends SinkConfig
   final case class BufferConfig(byteLimit: Long, recordLimit: Long, timeLimit: Long)

--- a/2-collectors/scala-stream-collector/examples/config.hocon.sample
+++ b/2-collectors/scala-stream-collector/examples/config.hocon.sample
@@ -160,6 +160,18 @@ collector {
       #brokers = "{{kafkaBrokers}}"
       ## Number of retries to perform before giving up on sending a record
       #retries = 0
+      # The kafka producer has a variety of possible configuration options defined at
+      # https://kafka.apache.org/documentation/#producerconfigs
+      # Some values are set to other values from this config by default:
+      # "bootstrap.servers" -> brokers
+      # retries             -> retries
+      # "buffer.memory"     -> buffer.byteLimit
+      # "linger.ms"         -> buffer.timeLimit
+      #producerConf {
+      #  acks = all
+      #  "key.serializer"     = "org.apache.kafka.common.serialization.StringSerializer"
+      #  "value.serializer"   = "org.apache.kafka.common.serialization.StringSerializer"
+      #}
 
       # Or NSQ
       ## Host name for nsqd

--- a/2-collectors/scala-stream-collector/kafka/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/KafkaSink.scala
+++ b/2-collectors/scala-stream-collector/kafka/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/KafkaSink.scala
@@ -17,8 +17,8 @@ package sinks
 import java.util.Properties
 
 import org.apache.kafka.clients.producer._
-
 import model._
+import scala.collection.JavaConverters._
 
 /**
  * Kafka Sink for the Scala collector
@@ -54,6 +54,8 @@ class KafkaSink(
       "org.apache.kafka.common.serialization.StringSerializer")
     props.put("value.serializer",
       "org.apache.kafka.common.serialization.ByteArraySerializer")
+
+    props.putAll(kafkaConfig.producerConf.getOrElse(Map()).asJava)
 
     new KafkaProducer[String, Array[Byte]](props)
   }


### PR DESCRIPTION
This PR adds a Map to the Kafka section of the config.hocon. The map will be applied to the Kafka producer and overrides the default config