### PR TITLE
Stream enrich: Extend config to override kafka producer and consumer config

### DIFF
--- a/3-enrich/stream-enrich/core/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/Amodel.scala
+++ b/3-enrich/stream-enrich/core/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/Amodel.scala
@@ -65,7 +65,11 @@ object model {
       case _                 => s"https://kinesis.$region.amazonaws.com"
     })
   }
-  final case class Kafka(brokers: String, retries: Int) extends SourceSinkConfig
+  final case class Kafka(
+    brokers: String,
+    retries: Int,
+    consumerConf: Option[Map[String,String]]
+  ) extends SourceSinkConfig
   final case class Nsq(
     rawChannel: String,
     host: String,

--- a/3-enrich/stream-enrich/core/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/Amodel.scala
+++ b/3-enrich/stream-enrich/core/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/Amodel.scala
@@ -68,7 +68,8 @@ object model {
   final case class Kafka(
     brokers: String,
     retries: Int,
-    consumerConf: Option[Map[String,String]]
+    consumerConf: Option[Map[String,String]],
+    producerConf: Option[Map[String,String]]
   ) extends SourceSinkConfig
   final case class Nsq(
     rawChannel: String,

--- a/3-enrich/stream-enrich/core/src/test/scala/com.snowplowanalytics.snowplow.enrich.stream/SpecHelpers.scala
+++ b/3-enrich/stream-enrich/core/src/test/scala/com.snowplowanalytics.snowplow.enrich.stream/SpecHelpers.scala
@@ -157,7 +157,7 @@ object SpecHelpers {
       streams = StreamsConfig(
         InConfig("raw"),
         OutConfig("enriched", Some("pii"), "bad", "partitionkey"),
-        Kafka("brokers", 1, None),
+        Kafka("brokers", 1, None, None),
         BufferConfig(1000L, 100L, 1200L),
         "appName"
       ),

--- a/3-enrich/stream-enrich/core/src/test/scala/com.snowplowanalytics.snowplow.enrich.stream/SpecHelpers.scala
+++ b/3-enrich/stream-enrich/core/src/test/scala/com.snowplowanalytics.snowplow.enrich.stream/SpecHelpers.scala
@@ -157,7 +157,7 @@ object SpecHelpers {
       streams = StreamsConfig(
         InConfig("raw"),
         OutConfig("enriched", Some("pii"), "bad", "partitionkey"),
-        Kafka("brokers", 1),
+        Kafka("brokers", 1, None),
         BufferConfig(1000L, 100L, 1200L),
         "appName"
       ),

--- a/3-enrich/stream-enrich/examples/config.hocon.sample
+++ b/3-enrich/stream-enrich/examples/config.hocon.sample
@@ -96,6 +96,18 @@ enrich {
       brokers = "{{kafkaBrokers}}"
       # Number of retries to perform before giving up on sending a record
       retries = 0
+      # The kafka producer has a variety of possible configuration options defined at
+      # https://kafka.apache.org/documentation/#producerconfigs
+      # Some values are set to other values from this config by default:
+      # "bootstrap.servers" -> brokers
+      # retries             -> retries
+      # "buffer.memory"     -> buffer.byteLimit
+      # "linger.ms"         -> buffer.timeLimit
+      #producerConf {
+      #  acks = all
+      #  "key.serializer"     = "org.apache.kafka.common.serialization.StringSerializer"
+      #  "value.serializer"   = "org.apache.kafka.common.serialization.StringSerializer"
+      #}
       # The kafka consumer has a variety of possible configuration options defined at
       # https://kafka.apache.org/documentation/#consumerconfigs
       # Some values are set to other values from this config by default:

--- a/3-enrich/stream-enrich/examples/config.hocon.sample
+++ b/3-enrich/stream-enrich/examples/config.hocon.sample
@@ -96,6 +96,19 @@ enrich {
       brokers = "{{kafkaBrokers}}"
       # Number of retries to perform before giving up on sending a record
       retries = 0
+      # The kafka consumer has a variety of possible configuration options defined at
+      # https://kafka.apache.org/documentation/#consumerconfigs
+      # Some values are set to other values from this config by default:
+      # "bootstrap.servers" -> brokers
+      # "group.id"          -> appName
+      #consumerConf {
+      #  "enable.auto.commit" = true
+      #  "auto.commit.interval.ms" = 1000
+      #  "auto.offset.reset"  = earliest
+      #  "session.timeout.ms" = 30000
+      #  "key.deserializer"   = "org.apache.kafka.common.serialization.StringDeserializer"
+      #  "value.deserializer" = "org.apache.kafka.common.serialization.ByteArrayDeserializer"
+      #}
 
       # Or NSQ
       ## Channel name for nsq source

--- a/3-enrich/stream-enrich/kafka/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/sinks/KafkaSink.scala
+++ b/3-enrich/stream-enrich/kafka/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/sinks/KafkaSink.scala
@@ -22,6 +22,8 @@ package sinks
 
 import java.util.Properties
 
+import scala.collection.JavaConverters._
+
 import org.apache.kafka.clients.producer._
 
 import scalaz._
@@ -47,6 +49,7 @@ object KafkaSink {
     bufferConfig: BufferConfig
   ): KafkaProducer[String, String] = {
     val properties = createProperties(kafkaConfig, bufferConfig)
+    properties.putAll(kafkaConfig.producerConf.getOrElse(Map()).asJava)
     new KafkaProducer[String, String](properties)
   }
 

--- a/3-enrich/stream-enrich/kafka/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/sources/KafkaSource.scala
+++ b/3-enrich/stream-enrich/kafka/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/sources/KafkaSource.scala
@@ -119,6 +119,7 @@ class KafkaSource private (
     brokers: String,
     groupId: String): KafkaConsumer[String, Array[Byte]] = {
     val properties = createProperties(brokers, groupId)
+    properties.putAll(kafkaConfig.consumerConf.getOrElse(Map()).asJava)
     new KafkaConsumer[String, Array[Byte]](properties)
   }
 


### PR DESCRIPTION
Based on PR https://github.com/snowplow/snowplow/pull/3938 this PR extends the configuration of [stream-enrich](https://github.com/snowplow/snowplow/tree/master/3-enrich/stream-enrich)  to override the configuration of the kafka producer and consumer.