### PR TITLE
Allow to override config settings with ENV variables.

### DIFF
--- a/2-collectors/scala-stream-collector/examples/config.hocon.sample
+++ b/2-collectors/scala-stream-collector/examples/config.hocon.sample
@@ -21,7 +21,7 @@ collector {
   # The collector runs as a web service specified on the following interface and port.
   interface = "0.0.0.0"
   interface = ${?COLLECTOR_INTERFACE}
-  port = "{{collectorPort}}"
+  port = {{collectorPort}}
   port = ${?COLLECTOR_PORT}
 
   # Configure the P3P policy header.
@@ -49,15 +49,15 @@ collector {
   cookie {
     enabled = true
     enabled = ${?COLLECTOR_COOKIE_ENABLED}
-    expiration = "{{cookieExpiration}}" # e.g. "365 days"
+    expiration = {{cookieExpiration}} # e.g. "365 days"
     expiration = ${?COLLECTOR_COOKIE_EXPIRATION}
     # Network cookie name
-    name = "{{collectorCookieName}}"
+    name = {{collectorCookieName}}
     name = ${?COLLECTOR_COOKIE_NAME}
     # The domain is optional and will make the cookie accessible to other
     # applications on the domain. Comment out this line to tie cookies to
     # the collector's full domain
-    domain = "{{cookieDomain}}"
+    domain = {{cookieDomain}}
     domain = ${?COLLECTOR_COOKIE_DOMAIN}
   }
 
@@ -68,9 +68,9 @@ collector {
   doNotTrackCookie {
     enabled = false
     enabled = ${?COLLECTOR_DO_NOT_TRACK_COOKIE_ENABLED}
-    name = "{{doNotTrackCookieName}}"
+    name = {{doNotTrackCookieName}}
     name = ${?COLLECTOR_DO_NOT_TRACK_COOKIE_NAME}
-    value = "{{doNotTrackCookieValue}}"
+    value = {{doNotTrackCookieValue}}
     value = ${?COLLECTOR_DO_NOT_TRACK_COOKIE_VALUE}
   }
 
@@ -125,11 +125,11 @@ collector {
 
   streams {
     # Events which have successfully been collected will be stored in the good stream/topic
-    good = "{{good}}"
+    good = {{good}}
     good = ${?COLLECTOR_STREAMS_GOOD}
 
     # Events that are too big (w.r.t Kinesis 1MB limit) will be stored in the bad stream/topic
-    bad = "{{bad}}"
+    bad = {{bad}}
     bad = ${?COLLECTOR_STREAMS_BAD}
 
     # Whether to use the incoming event's ip as the partition key for the good stream/topic
@@ -146,7 +146,7 @@ collector {
       enabled = ${?COLLECTOR_STREAMS_SINK_ENABLED}
 
       # Region where the streams are located
-      region = "{{kinesisRegion}}"
+      region = {{kinesisRegion}}
       region = ${?COLLECTOR_STREAMS_SINK_REGION}
 
       ## Optional endpoint url configuration to override aws kinesis endpoints,
@@ -172,9 +172,9 @@ collector {
 
       # Minimum and maximum backoff periods, in milliseconds
       backoffPolicy {
-        minBackoff = "{{minBackoffMillis}}"
+        minBackoff = {{minBackoffMillis}}
         minBackoff = ${?COLLECTOR_STREAMS_SINK_MIN_BACKOFF}
-        maxBackoff = "{{maxBackoffMillis}}"
+        maxBackoff = {{maxBackoffMillis}}
         maxBackoff = ${?COLLECTOR_STREAMS_SINK_MAX_BACKOFF}
       }
 
@@ -190,13 +190,13 @@ collector {
       #}
 
       # Or Kafka
-      #brokers = "{{kafkaBrokers}}"
+      #brokers = {{kafkaBrokers}}
       ## Number of retries to perform before giving up on sending a record
       #retries = 0
 
       # Or NSQ
       ## Host name for nsqd
-      #host = "{{nsqHost}}"
+      #host = {{nsqHost}}
       ## TCP port for nsqd, 4150 by default
       #port = {{nsqdPort}}
     }
@@ -208,11 +208,11 @@ collector {
     # - the combined size of the stored records reaches byte-limit or
     # - the time in milliseconds since the buffer was last emptied reaches time-limit
     buffer {
-      byteLimit = "{{bufferByteThreshold}}"
+      byteLimit = {{bufferByteThreshold}}
       byteLimit = ${?COLLECTOR_STREAMS_BUFFER_BYTE_LIMIT}
-      recordLimit = "{{bufferRecordThreshold}}" # Not supported by Kafka; will be ignored
+      recordLimit = {{bufferRecordThreshold}} # Not supported by Kafka; will be ignored
       recordLimit = ${?COLLECTOR_STREAMS_BUFFER_RECORD_LIMIT}
-      timeLimit = "{{bufferTimeThreshold}}"
+      timeLimit = {{bufferTimeThreshold}}
       timeLimit = ${?COLLECTOR_STREAMS_BUFFER_TIME_LIMIT}
     }
   }

--- a/2-collectors/scala-stream-collector/examples/config.hocon.sample
+++ b/2-collectors/scala-stream-collector/examples/config.hocon.sample
@@ -20,7 +20,9 @@
 collector {
   # The collector runs as a web service specified on the following interface and port.
   interface = "0.0.0.0"
-  port = {{collectorPort}}
+  interface = ${?COLLECTOR_INTERFACE}
+  port = "{{collectorPort}}"
+  port = ${?COLLECTOR_PORT}
 
   # Configure the P3P policy header.
   p3p {
@@ -34,22 +36,29 @@ collector {
   crossDomain {
     enabled = false
     # Domains that are granted access, *.acme.com will match http://acme.com and http://sub.acme.com
+    enabled = ${?COLLECTOR_CROSS_DOMAIN_ENABLED}
     domains = [ "*" ]
+    domains = [ ${?COLLECTOR_CROSS_DOMAIN_DOMAIN} ]
     # Whether to only grant access to HTTPS or both HTTPS and HTTP sources
     secure = true
+    secure = ${?COLLECTOR_CROSS_DOMAIN_SECURE}
   }
 
   # The collector returns a cookie to clients for user identification
   # with the following domain and expiration.
   cookie {
     enabled = true
-    expiration = {{cookieExpiration}} # e.g. "365 days"
+    enabled = ${?COLLECTOR_COOKIE_ENABLED}
+    expiration = "{{cookieExpiration}}" # e.g. "365 days"
+    expiration = ${?COLLECTOR_COOKIE_EXPIRATION}
     # Network cookie name
-    name = {{collectorCookieName}}
+    name = "{{collectorCookieName}}"
+    name = ${?COLLECTOR_COOKIE_NAME}
     # The domain is optional and will make the cookie accessible to other
     # applications on the domain. Comment out this line to tie cookies to
     # the collector's full domain
     domain = "{{cookieDomain}}"
+    domain = ${?COLLECTOR_COOKIE_DOMAIN}
   }
 
   # If you have a do not track cookie in place, the Scala Stream Collector can respect it by
@@ -58,8 +67,11 @@ collector {
   # The cookie name and value must match the configuration below.
   doNotTrackCookie {
     enabled = false
-    name = {{doNotTrackCookieName}}
-    value = {{doNotTrackCookieValue}}
+    enabled = ${?COLLECTOR_DO_NOT_TRACK_COOKIE_ENABLED}
+    name = "{{doNotTrackCookieName}}"
+    name = ${?COLLECTOR_DO_NOT_TRACK_COOKIE_NAME}
+    value = "{{doNotTrackCookieValue}}"
+    value = ${?COLLECTOR_DO_NOT_TRACK_COOKIE_VALUE}
   }
 
   # When enabled and the cookie specified above is missing, performs a redirect to itself to check
@@ -67,15 +79,19 @@ collector {
   # fallbackNetworkId is used instead of generating a new random one.
   cookieBounce {
     enabled = false
+    enabled = ${?COLLECTOR_COOKIE_BOUNCE_ENABLED}
     # The name of the request parameter which will be used on redirects checking that third-party
     # cookies work.
     name = "n3pc"
+    name = ${?COLLECTOR_COOKIE_BOUNCE_NAME}
     # Network user id to fallback to when third-party cookies are blocked.
     fallbackNetworkUserId = "00000000-0000-4000-A000-000000000000"
+    fallbackNetworkUserId = ${?COLLECTOR_COOKIE_BOUNCE_FALLBACK_NETWORK_USER_ID}
     # Optionally, specify the name of the header containing the originating protocol for use in the
     # bounce redirect location. Use this if behind a load balancer that performs SSL termination.
     # The value of this header must be http or https. Example, if behind an AWS Classic ELB.
     forwardedProtocolHeader = "X-Forwarded-Proto"
+    forwardedProtocolHeader = ${?COLLECTOR_COOKIE_BOUNCE_FORWARDED_PROTOCOL_HEADER}
   }
 
   # When enabled, the redirect url passed via the `u` query parameter is scanned for a placeholder
@@ -83,34 +99,43 @@ collector {
   # specified, the default value is `${SP_NUID}`.
   redirectMacro {
     enabled = false
+    enabled = ${?COLLECTOR_REDIRECT_MACRO_ENABLED}
     # Optional custom placeholder token (defaults to the literal `${SP_NUID}`)
     placeholder = "[TOKEN]"
+    placeholder = ${?COLLECTOR_REDIRECT_REDIRECT_MACRO_PLACEHOLDER}
   }
 
   # Customize response handling for requests for the root path ("/").
   # Useful if you need to redirect to web content or privacy policies regarding the use of this collector.
   rootResponse {
     enabled = false
+    enabled = ${?COLLECTOR_ROOT_RESPONSE_ENABLED}
     statusCode = 302
+    statusCode = ${?COLLECTOR_ROOT_STATUS_CODE}
     # Optional, defaults to empty map
     headers = {
-        Location = "https://127.0.0.1/",
-        X-Custom = "something"
+      Location = "https://127.0.0.1/",
+      Location = ${?COLLECTOR_ROOT_RESPONSE_HEADERS_LOCATION},
+      X-Custom = "something"
     }
     # Optional, defaults to empty string
     body = "302, redirecting"
+    body = ${?COLLECTOR_ROOT_RESPONSE_BODY}
   }
 
   streams {
     # Events which have successfully been collected will be stored in the good stream/topic
-    good = {{good}}
+    good = "{{good}}"
+    good = ${?COLLECTOR_STREAMS_GOOD}
 
     # Events that are too big (w.r.t Kinesis 1MB limit) will be stored in the bad stream/topic
-    bad = {{bad}}
+    bad = "{{bad}}"
+    bad = ${?COLLECTOR_STREAMS_BAD}
 
     # Whether to use the incoming event's ip as the partition key for the good stream/topic
     # Note: Nsq does not make use of partition key.
     useIpAddressAsPartitionKey = false
+    useIpAddressAsPartitionKey = ${?COLLECTOR_STREAMS_USE_IP_ADDRESS_AS_PARTITION_KEY}
 
     # Enable the chosen sink by uncommenting the appropriate configuration
     sink {
@@ -118,16 +143,20 @@ collector {
       # To use stdout, comment or remove everything in the "collector.streams.sink" section except
       # "enabled" which should be set to "stdout".
       enabled = kinesis
+      enabled = ${?COLLECTOR_STREAMS_SINK_ENABLED}
 
       # Region where the streams are located
-      region = {{kinesisRegion}}
+      region = "{{kinesisRegion}}"
+      region = ${?COLLECTOR_STREAMS_SINK_REGION}
 
       ## Optional endpoint url configuration to override aws kinesis endpoints,
       ## this can be used to specify local endpoints when using localstack
       # customEndpoint = {{kinesisEndpoint}}
+      # customEndpoint = ${?COLLECTOR_STREAMS_SINK_CUSTOM_ENDPOINT}
 
       # Thread pool size for Kinesis API requests
       threadPoolSize = 10
+      threadPoolSize = ${?COLLECTOR_STREAMS_SINK_THREAD_POOL_SIZE}
 
       # The following are used to authenticate for the Amazon Kinesis sink.
       # If both are set to 'default', the default provider chain is used
@@ -135,14 +164,18 @@ collector {
       # If both are set to 'iam', use AWS IAM Roles to provision credentials.
       # If both are set to 'env', use environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
       aws {
-        accessKey = iam
-        secretKey = iam
+        accessKey = "iam"
+        accessKey = ${?COLLECTOR_STREAMS_SINK_AWS_ACCESS_KEY}
+        secretKey = "iam"
+        secretKey = ${?COLLECTOR_STREAMS_SINK_AWS_SECRET_KEY}
       }
 
       # Minimum and maximum backoff periods, in milliseconds
       backoffPolicy {
-        minBackoff = {{minBackoffMillis}}
-        maxBackoff = {{maxBackoffMillis}}
+        minBackoff = "{{minBackoffMillis}}"
+        minBackoff = ${?COLLECTOR_STREAMS_SINK_MIN_BACKOFF}
+        maxBackoff = "{{maxBackoffMillis}}"
+        maxBackoff = ${?COLLECTOR_STREAMS_SINK_MAX_BACKOFF}
       }
 
       # Or Google Pubsub
@@ -175,9 +208,12 @@ collector {
     # - the combined size of the stored records reaches byte-limit or
     # - the time in milliseconds since the buffer was last emptied reaches time-limit
     buffer {
-      byteLimit = {{bufferByteThreshold}}
-      recordLimit = {{bufferRecordThreshold}} # Not supported by Kafka; will be ignored
-      timeLimit = {{bufferTimeThreshold}}
+      byteLimit = "{{bufferByteThreshold}}"
+      byteLimit = ${?COLLECTOR_STREAMS_BUFFER_BYTE_LIMIT}
+      recordLimit = "{{bufferRecordThreshold}}" # Not supported by Kafka; will be ignored
+      recordLimit = ${?COLLECTOR_STREAMS_BUFFER_RECORD_LIMIT}
+      timeLimit = "{{bufferTimeThreshold}}"
+      timeLimit = ${?COLLECTOR_STREAMS_BUFFER_TIME_LIMIT}
     }
   }
 }
@@ -186,7 +222,9 @@ collector {
 # http://doc.akka.io/docs/akka/current/scala/general/configuration.html
 akka {
   loglevel = DEBUG # 'OFF' for no logging, 'DEBUG' for all logging.
+  loglevel = ${?AKKA_LOGLEVEL}
   loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loggers = [${?AKKA_LOGGERS}]
 
   # akka-http is the server the Stream collector uses and has configurable options defined at
   # http://doc.akka.io/docs/akka-http/current/scala/http/configuration.html
@@ -195,13 +233,17 @@ akka {
     # should be set. By default, this is disabled, and enabling it
     # adds the 'Remote-Address' header to every request automatically.
     remote-address-header = on
+    remote-address-header = ${?AKKA_HTTP_SERVER_REMOTE_ADDRESS_HEADER}
 
     raw-request-uri-header = on
+    raw-request-uri-header = ${?AKKA_HTTP_SERVER_RAW_REQUEST_URI_HEADER}
 
     # Define the maximum request length (the default is 2048)
     parsing {
       max-uri-length = 32768
+      max-uri-lenght = ${?AKKA_HTTP_SERVER_PARSING_MAX_URI_LENGHT}
       uri-parsing-mode = relaxed
+      uri-parsing-mode = ${?AKKA_HTTP_SERVER_PARSING_URI_PARSING_MODE}
     }
   }
 }

--- a/3-enrich/stream-enrich/examples/config.hocon.sample
+++ b/3-enrich/stream-enrich/examples/config.hocon.sample
@@ -20,16 +20,20 @@ enrich {
 
     in {
       # Stream/topic where the raw events to be enriched are located
-      raw = {{streamsInRaw}}
+      raw = "{{streamsInRaw}}"
+      raw = ${?ENRICH_STREAMS_IN_RAW}
     }
 
     out {
       # Stream/topic where the events that were successfully enriched will end up
-      enriched = {{outEnriched}}
+      enriched = "{{outEnriched}}"
+      enriched = ${?ENRICH_STREAMS_OUT_ENRICHED}
       # Stream/topic where the event that failed enrichment will be stored
-      bad = {{outBad}}
+      bad = "{{outBad}}"
+      bad = ${?ENRICH_STREAMS_OUT_BAD}
       # Stream/topic where the pii tranformation events will end up
-      pii = {{outPii}}
+      pii = "{{outPii}}"
+      pii = ${?ENRICH_STREAMS_OUT_PII}
 
       # How the output stream/topic will be partitioned.
       # Possible partition keys are: event_id, event_fingerprint, domain_userid, network_userid,
@@ -38,7 +42,8 @@ enrich {
       # possible parittion keys correspond to.
       # Otherwise, the partition key will be a random UUID.
       # Note: Nsq does not make use of partition key.
-      partitionKey = {{partitionKeyName}}
+      partitionKey = "{{partitionKeyName}}"
+      partitionKey = ${?ENRICH_STREAMS_OUT_PARTITION_KEY}
     }
 
     # Configuration shown is for Kafka, to use another uncomment the appropriate configuration
@@ -52,26 +57,32 @@ enrich {
       # 'kafka' for reading / writing to a Kafka topic
       # 'nsq' for reading / writing to a Nsq topic
       # 'stdin' for reading from stdin and writing to stdout and stderr
-      enabled =  {{sinkType}}
+      enabled =  "{{sinkType}}"
+      enabled =  ${?ENRICH_STREAMS_SOURCE_SINK_ENABLED}
 
       # Region where the streams are located (AWS region, pertinent to kinesis sink/source type)
-      # region = {{region}}
+      # region = "{{region}}"
+      # region = ${?ENRICH_STREAMS_SOURCE_SINK_REGION}
 
       ## Optional endpoint url configuration to override aws kinesis endpoints,
       ## this can be used to specify local endpoints when using localstack
-      # customEndpoint = {{kinesisEndpoint}}
+      # customEndpoint = "{{kinesisEndpoint}}"
+      # customEndpoint = ${?ENRICH_STREAMS_SOURCE_SINK_CUSTOM_ENDPOINT}
 
       # AWS credentials
       # If both are set to 'default', use the default AWS credentials provider chain.
       # If both are set to 'iam', use AWS IAM Roles to provision credentials.
       # If both are set to 'env', use env variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
       # aws {
-      #   accessKey = iam
-      #   secretKey = iam
+      #   accessKey = "iam"
+      #   accessKey = ${?ENRICH_STREAMS_SOURCE_SINK_AWS_ACCESS_KEY}
+      #   secretKey = "iam"
+      #   secretKey = ${?ENRICH_STREAMS_SOURCE_SINK_AWS_SECRET_KEY}
       # }
 
       # Maximum number of records to get from Kinesis per call to GetRecords
       # maxRecords = 10000
+      # maxRecords = ${?ENRICH_MAX_RECORDS}
 
       # LATEST: most recent data.
       # TRIM_HORIZON: oldest available data.
@@ -79,17 +90,21 @@ enrich {
       # Note: This only effects the first run of this application on a stream.
       # (pertinent to kinesis source type)
       # initialPosition = TRIM_HORIZON
+      # initialPosition = ${?ENRICH_STREAMS_SOURCE_SINK_INITIAL_POSITION}
 
       # Need to be specified when initial-position is "AT_TIMESTAMP".
       # Timestamp format need to be in "yyyy-MM-ddTHH:mm:ssZ".
       # Ex: "2017-05-17T10:00:00Z"
       # Note: Time need to specified in UTC.
       initialTimestamp = "{{initialTimestamp}}"
+      initialTimestamp = ${?ENRICH_STREAMS_SOURCE_SINK_INITIAL_TIMESTAMP}
 
       # Minimum and maximum backoff periods, in milliseconds
       backoffPolicy {
-        minBackoff = {{enrichStreamsOutMinBackoff}}
-        maxBackoff = {{enrichStreamsOutMaxBackoff}}
+        minBackoff = "{{enrichStreamsOutMinBackoff}}"
+        minBackoff = ${?ENRICH_STREAMS_SOURCE_SINK_BACKOFF_POLICY_MIN_BACKOFF}
+        maxBackoff = "{{enrichStreamsOutMaxBackoff}}"
+        maxBackoff = ${?ENRICH_STREAMS_SOURCE_SINK_BACKOFF_POLICY_MAX_BACKOFF}
       }
 
       # Or Kafka (Comment out for other types)
@@ -120,24 +135,32 @@ enrich {
     # - the time in milliseconds since it was last emptied exceeds timeLimit when
     #   a new event enters the buffer
     buffer {
-      byteLimit = {{bufferByteThreshold}}
-      recordLimit = {{bufferRecordThreshold}} # Not supported by Kafka; will be ignored
-      timeLimit = {{bufferTimeThreshold}}
+      byteLimit = "{{bufferByteThreshold}}"
+      byteLimit = ${?ENRICH_STREAMS_BUFFER_BYTE_LIMIT}
+      recordLimit = "{{bufferRecordThreshold}}" # Not supported by Kafka; will be ignored
+      recordLimit = ${?ENRICH_STREAMS_BUFFER_RECORD_LIMIT}
+      timeLimit = "{{bufferTimeThreshold}}"
+      timeLimit = ${?ENRICH_STREAMS_BUFFER_TIME_LIMIT}
     }
 
     # Used for a DynamoDB table to maintain stream state.
     # Used as the Kafka consumer group ID.
     # Used as the Google PubSub subscription name.
     appName = "{{appName}}"
+    appName = ${?ENRICH_STREAMS_APP_NAME}
   }
 
   # Optional section for tracking endpoints
   monitoring {
     snowplow {
       collectorUri = "{{collectorUri}}"
+      collectorUri = ${?ENRICH_MONITORING_COLLECTOR_URI}
       collectorPort = 80
-      appId = {{enrichAppName}}
+      collectorPort = ${?ENRICH_MONITORING_COLLECTOR_PORT}
+      appId = "{{enrichAppName}}"
+      appId = ${?ENRICH_MONITORING_APP_ID}
       method = GET
+      method = ${?ENRICH_MONITORING_METHOD}
     }
   }
 }

--- a/3-enrich/stream-enrich/examples/config.hocon.sample
+++ b/3-enrich/stream-enrich/examples/config.hocon.sample
@@ -20,19 +20,19 @@ enrich {
 
     in {
       # Stream/topic where the raw events to be enriched are located
-      raw = "{{streamsInRaw}}"
+      raw = {{streamsInRaw}}
       raw = ${?ENRICH_STREAMS_IN_RAW}
     }
 
     out {
       # Stream/topic where the events that were successfully enriched will end up
-      enriched = "{{outEnriched}}"
+      enriched = {{outEnriched}}
       enriched = ${?ENRICH_STREAMS_OUT_ENRICHED}
       # Stream/topic where the event that failed enrichment will be stored
-      bad = "{{outBad}}"
+      bad = {{outBad}}
       bad = ${?ENRICH_STREAMS_OUT_BAD}
       # Stream/topic where the pii tranformation events will end up
-      pii = "{{outPii}}"
+      pii = {{outPii}}
       pii = ${?ENRICH_STREAMS_OUT_PII}
 
       # How the output stream/topic will be partitioned.
@@ -42,7 +42,7 @@ enrich {
       # possible parittion keys correspond to.
       # Otherwise, the partition key will be a random UUID.
       # Note: Nsq does not make use of partition key.
-      partitionKey = "{{partitionKeyName}}"
+      partitionKey = {{partitionKeyName}}
       partitionKey = ${?ENRICH_STREAMS_OUT_PARTITION_KEY}
     }
 
@@ -57,16 +57,16 @@ enrich {
       # 'kafka' for reading / writing to a Kafka topic
       # 'nsq' for reading / writing to a Nsq topic
       # 'stdin' for reading from stdin and writing to stdout and stderr
-      enabled =  "{{sinkType}}"
+      enabled =  {{sinkType}}
       enabled =  ${?ENRICH_STREAMS_SOURCE_SINK_ENABLED}
 
       # Region where the streams are located (AWS region, pertinent to kinesis sink/source type)
-      # region = "{{region}}"
+      # region = {{region}}
       # region = ${?ENRICH_STREAMS_SOURCE_SINK_REGION}
 
       ## Optional endpoint url configuration to override aws kinesis endpoints,
       ## this can be used to specify local endpoints when using localstack
-      # customEndpoint = "{{kinesisEndpoint}}"
+      # customEndpoint = {{kinesisEndpoint}}
       # customEndpoint = ${?ENRICH_STREAMS_SOURCE_SINK_CUSTOM_ENDPOINT}
 
       # AWS credentials
@@ -96,19 +96,19 @@ enrich {
       # Timestamp format need to be in "yyyy-MM-ddTHH:mm:ssZ".
       # Ex: "2017-05-17T10:00:00Z"
       # Note: Time need to specified in UTC.
-      initialTimestamp = "{{initialTimestamp}}"
+      initialTimestamp = {{initialTimestamp}}
       initialTimestamp = ${?ENRICH_STREAMS_SOURCE_SINK_INITIAL_TIMESTAMP}
 
       # Minimum and maximum backoff periods, in milliseconds
       backoffPolicy {
-        minBackoff = "{{enrichStreamsOutMinBackoff}}"
+        minBackoff = {{enrichStreamsOutMinBackoff}}
         minBackoff = ${?ENRICH_STREAMS_SOURCE_SINK_BACKOFF_POLICY_MIN_BACKOFF}
-        maxBackoff = "{{enrichStreamsOutMaxBackoff}}"
+        maxBackoff = {{enrichStreamsOutMaxBackoff}}
         maxBackoff = ${?ENRICH_STREAMS_SOURCE_SINK_BACKOFF_POLICY_MAX_BACKOFF}
       }
 
       # Or Kafka (Comment out for other types)
-      brokers = "{{kafkaBrokers}}"
+      brokers = {{kafkaBrokers}}
       # Number of retries to perform before giving up on sending a record
       retries = 0
 
@@ -116,13 +116,13 @@ enrich {
       ## Channel name for nsq source
       ## If more than one application is reading from the same NSQ topic at the same time,
       ## all of them must have the same channel name
-      #rawChannel = "{{nsqSourceChannelName}}"
+      #rawChannel = {{nsqSourceChannelName}}
       ## Host name for nsqd
-      #host = "{{nsqHost}}"
+      #host = {{nsqHost}}
       ## TCP port for nsqd, 4150 by default
       #port = {{nsqdPort}}
       ## Host name for lookupd
-      #lookupHost = "{{lookupHost}}"
+      #lookupHost = {{lookupHost}}
       ## HTTP port for nsqlookupd, 4161 by default
       #lookupPort = {{nsqlookupdPort}}
     }
@@ -135,29 +135,29 @@ enrich {
     # - the time in milliseconds since it was last emptied exceeds timeLimit when
     #   a new event enters the buffer
     buffer {
-      byteLimit = "{{bufferByteThreshold}}"
+      byteLimit = {{bufferByteThreshold}}
       byteLimit = ${?ENRICH_STREAMS_BUFFER_BYTE_LIMIT}
-      recordLimit = "{{bufferRecordThreshold}}" # Not supported by Kafka; will be ignored
+      recordLimit = {{bufferRecordThreshold}} # Not supported by Kafka; will be ignored
       recordLimit = ${?ENRICH_STREAMS_BUFFER_RECORD_LIMIT}
-      timeLimit = "{{bufferTimeThreshold}}"
+      timeLimit = {{bufferTimeThreshold}}
       timeLimit = ${?ENRICH_STREAMS_BUFFER_TIME_LIMIT}
     }
 
     # Used for a DynamoDB table to maintain stream state.
     # Used as the Kafka consumer group ID.
     # Used as the Google PubSub subscription name.
-    appName = "{{appName}}"
+    appName = {{appName}}
     appName = ${?ENRICH_STREAMS_APP_NAME}
   }
 
   # Optional section for tracking endpoints
   monitoring {
     snowplow {
-      collectorUri = "{{collectorUri}}"
+      collectorUri = {{collectorUri}}
       collectorUri = ${?ENRICH_MONITORING_COLLECTOR_URI}
       collectorPort = 80
       collectorPort = ${?ENRICH_MONITORING_COLLECTOR_PORT}
-      appId = "{{enrichAppName}}"
+      appId = {{enrichAppName}}
       appId = ${?ENRICH_MONITORING_APP_ID}
       method = GET
       method = ${?ENRICH_MONITORING_METHOD}


### PR DESCRIPTION
In order to configure the collector and enricher using environment variables in AWS Beanstalk, ECS or even kubernetes with config maps instead of a fixed config file, we augmented the hocon sample files with additional (and conditional) evaluation of env variables. We used a naming scheme for transforming the nested hocon keys into env variables:
Each nested level will be separated with an underscore and appended. Also Camel case is turned separate words joined with underscore. All characters are upper cased then.
    
    collector {
      crossDomain {
        enabled
      }
    }

becomes:
`COLLECTOR_CROSS_DOMAIN_ENABLED`


I hope this PR will make the adoption of snowplow on docker much easier. 
    
    docker run \
      -v $PWD/:/snowplow/config \
      -e COLLECTOR_COOKIE_DOMAIN="your-domain" \
      -e COLLECTOR_COOKIE_NAME="custom-cookie-name" \
      -e COLLECTOR_COOKIE_EXPIRATION="730 days" \
      -e COLLECTOR_PORT="8091" \
      -e GOOD_STREAM="good-stream-name" \
      -e BAD_STREAM="bad-stream-name" \
      -e MAX_BACKOFF_MILLIS=3000 \
      -e MIN_BACKOFF_MILLIS=600000 \
      -e AWS_REGION="us-east-1" \
      -e BUFFER_RECORD_THRESHOLD=100 \
      -e BUFFER_TIME_THRESHOLD=1000 \
      -e BUFFER_BYTE_THRESHOLD=102400 \
      -e AWS_ACCESS_KEY_ID=KEY \
      -e AWS_SECRET_ACCESS_KEY=SECRET \
      snowplow-docker-registry.bintray.io/snowplow/scala-stream-collector-kinesis:0.14.0 \
      --config /snowplow/config/config.hocon
