### PR TITLE
Avoid test interwining by disabling parallel execution

### DIFF
--- a/3-enrich/scala-common-enrich/build.sbt
+++ b/3-enrich/scala-common-enrich/build.sbt
@@ -25,6 +25,7 @@ lazy val root = project
   .settings(BuildSettings.formatting)
   .settings(BuildSettings.buildSettings)
   .settings(BuildSettings.publishSettings)
+  .settings(parallelExecution in Test := false)
   .settings(
     libraryDependencies ++= Seq(
       // Java


### PR DESCRIPTION
Some tests or resources are not completely isolated and hang the `sbt test` command in a powerful enough machine. 

This PR disables parallel execution of tests so they are executed sequentially.
