### PR TITLE
Scala Stream Collector: add Azure Event Hubs sink (closes #3270)

### DIFF
--- a/2-collectors/scala-stream-collector/build.sbt
+++ b/2-collectors/scala-stream-collector/build.sbt
@@ -92,3 +92,9 @@ lazy val stdout = project
   .settings(moduleName := "snowplow-stream-collector-stdout")
   .settings(allSettings)
   .dependsOn(core)
+
+lazy val eventhub = project
+  .settings(moduleName := "snowplow-stream-collector-eventhub")
+  .settings(allSettings)
+  .settings(libraryDependencies ++= Seq(Dependencies.Libraries.eventHub))
+  .dependsOn(core)

--- a/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
+++ b/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
@@ -101,6 +101,15 @@ package model {
   ) extends SinkConfig
   final case class Kafka(brokers: String, retries: Int) extends SinkConfig
   final case class Nsq(host: String, port: Int) extends SinkConfig
+  final case class EventHubKeys(goodAccessKeyName: String,
+                          goodAccessKey: String,
+                          badAccessKeyName: String,
+                          badAccessKey: String)
+  final case class EventHub(
+                             threadPoolSize: Int,
+                             domainName: String,
+                             eventHubKeys: EventHubKeys
+  ) extends SinkConfig
   case object Stdout extends SinkConfig
   final case class BufferConfig(byteLimit: Long, recordLimit: Long, timeLimit: Long)
   final case class StreamsConfig(

--- a/2-collectors/scala-stream-collector/eventhub/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/EventHubCollector.scala
+++ b/2-collectors/scala-stream-collector/eventhub/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/EventHubCollector.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2013-2018 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0, and
+ * you may not use this file except in compliance with the Apache License
+ * Version 2.0.  You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Apache License Version 2.0 is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the Apache License Version 2.0 for the specific language
+ * governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.collectors.scalastream
+
+import java.util.concurrent.ScheduledThreadPoolExecutor
+
+import scalaz._
+import Scalaz._
+
+import model._
+import sinks.EventHubSink
+
+object EventHubCollector extends Collector {
+
+  def main(args: Array[String]): Unit = {
+    val (collectorConf, akkaConf) = parseConfig(args)
+
+    val sinks = for {
+      ehConf <- collectorConf.streams.sink match {
+        case eh: EventHub => eh.right
+        case _ => new IllegalArgumentException("Configured sink is not EventHub").left
+      }
+      es = new ScheduledThreadPoolExecutor(ehConf.threadPoolSize)
+      goodStream = collectorConf.streams.good
+      badStream = collectorConf.streams.bad
+      good <- EventHubSink.createAndInitialize(
+        ehConf,
+        goodStream,
+        ehConf.domainName,
+        ehConf.eventHubKeys.goodAccessKeyName,
+        ehConf.eventHubKeys.goodAccessKey,
+        es)
+      bad <- EventHubSink.createAndInitialize(
+        ehConf,
+        badStream,
+        ehConf.domainName,
+        ehConf.eventHubKeys.badAccessKeyName,
+        ehConf.eventHubKeys.badAccessKey,
+        es)
+    } yield CollectorSinks(good, bad)
+
+    sinks match {
+      case \/-(s) => run(collectorConf, akkaConf, s)
+      case -\/(e) => throw e
+    }
+  }
+}

--- a/2-collectors/scala-stream-collector/eventhub/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/EventHubSink.scala
+++ b/2-collectors/scala-stream-collector/eventhub/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/EventHubSink.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2013-2018 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.collectors.scalastream.sinks
+
+import java.util.concurrent.ScheduledExecutorService
+import java.util.function.BiFunction
+
+import com.microsoft.azure.eventhubs.{ConnectionStringBuilder, EventData, EventHubClient}
+import com.snowplowanalytics.snowplow.collectors.scalastream.model.EventHub
+import scalaz._
+
+/** EventHubSink companion object with factory method */
+object EventHubSink {
+
+  /**
+   * Creates an EventHubSink
+   * Exists so that no threads can get a reference to the EventHubSink during its construction
+   * TODO: rm scalaz \/ once 2.12
+   */
+  def createAndInitialize(
+                           eventHubConfig: EventHub,
+                           streamName: String,
+                           domainName: String,
+                           sasKeyName: String,
+                           sasKey: String,
+                           executorService: ScheduledExecutorService
+  ): \/[Throwable, EventHubSink] = {
+
+    val connStrBuilder = new ConnectionStringBuilder()
+      .setEndpoint( streamName, domainName)
+      .setSasKeyName(sasKeyName)
+      .setSasKey(sasKey)
+
+    val client = \/.fromTryCatch(EventHubClient.createSync(connStrBuilder.toString, executorService))
+
+    client.map{c =>
+      new EventHubSink(c, streamName, executorService)
+    }
+  }
+}
+
+/**
+ * Eventhub Sink for the Scala collector.
+ */
+class EventHubSink private(
+  client: EventHubClient,
+  streamName: String,
+  executorService: ScheduledExecutorService
+) extends Sink {
+
+  // Records must not exceed MaxBytes - 1MB
+  val MaxBytes = 1000000L
+
+  implicit lazy val ec = concurrent.ExecutionContext.fromExecutorService(executorService)
+
+  private val biFun = new BiFunction[Void, Throwable, Void] {
+    override def apply(v: Void, t: Throwable): Void = {
+      if (t != null) sys.error(s"Sending event to EventHub failed: ${t.getMessage}")
+      null
+    }
+  }
+
+  override def storeRawEvents(events: List[Array[Byte]], key: String): List[Array[Byte]] = {
+    log.debug(s"Writing ${events.size} Thrift records to Eventhub $streamName at key $key")
+    events.foreach { event =>
+      val data = EventData.create(event)
+      client.send(data, key).handleAsync(biFun)
+    }
+    Nil
+  }
+}

--- a/2-collectors/scala-stream-collector/project/Dependencies.scala
+++ b/2-collectors/scala-stream-collector/project/Dependencies.scala
@@ -28,6 +28,7 @@ object Dependencies {
     val pubsub               = "0.37.0-beta"
     val kafka                = "1.0.1"
     val nsqClient            = "1.2.0"
+    val eventHub             = "2.4.0"
     val yodaTime             = "2.9.9"
     val slf4j                = "1.7.5"
     val config               = "1.3.1"
@@ -51,6 +52,7 @@ object Dependencies {
     val pubsub               = "com.google.cloud"      %  "google-cloud-pubsub"    % V.pubsub
     val kafkaClients         = "org.apache.kafka"      %  "kafka-clients"          % V.kafka
     val nsqClient            = "com.snowplowanalytics" %  "nsq-java-client"        % V.nsqClient
+    val eventHub             = "com.microsoft.azure"   %   "azure-eventhubs-eph"   % V.eventHub
     val yodaTime             = "joda-time"             %  "joda-time"              % V.yodaTime
     val slf4j                = "org.slf4j"             %  "slf4j-simple"           % V.slf4j
     val log4jOverSlf4j       = "org.slf4j"             %  "log4j-over-slf4j"       % V.slf4j


### PR DESCRIPTION
<!--
Thank you for contributing to Snowplow!

You'll find a small checklist below which should help speed up the review processs:

- [x] Have you signed the [contributor license agreement](https://github.com/snowplow/snowplow/wiki/CLA)?
- [x] Have you read the [contributing guide](https://github.com/snowplow/snowplow/blob/master/CONTRIBUTING.md)?
- [x] Have you added the appropriate unit tests?
- [x] Have you run the tests through `sbt test`?
- [x] Is your pull request against the `master` branch?
-->

Hi @BenFradet, Could you please have a quick look and let me know if this looks reasonable.  

The relevant collector-config looks like this : 
```
sink {
      # Choose between kinesis, googlepubsub, kafka, nsq, stdout or eventhub.
      enabled = eventhub

      # Thread pool size for EventHub API requests
      threadPoolSize = 10
      domainName = "servicebus.windows.net"

      eventHubKeys {
        goodAccessKeyName = ""
        goodAccessKey = ""
        badAccessKeyName = ""
        badAccessKey = ""
      }
```

