### PR TITLE
Scala Stream Collector: bump kafka producer client to 2.1.0

### DIFF
--- a/2-collectors/scala-stream-collector/project/Dependencies.scala
+++ b/2-collectors/scala-stream-collector/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
     // Java
     val awsSdk               = "1.11.290"
     val pubsub               = "0.37.0-beta"
-    val kafka                = "1.0.1"
+    val kafka                = "2.1.0"
     val nsqClient            = "1.2.0"
     val yodaTime             = "2.9.9"
     val slf4j                = "1.7.5"


### PR DESCRIPTION
This allows Scala Stream Collector to use new Kafka ProducerConfigs introduced in 2.1.0, e.g. _delivery.timeout.ms_
Together with new feature to set [arbitrary kafka producer settings](https://github.com/snowplow/snowplow/issues/3968) we can better customize our kafka sink.