### PR TITLE
Scala Common Enrich: Support multiple instances of API request enrichment

### DIFF
--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/UserAgentUtilsEnrichment.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/UserAgentUtilsEnrichment.scala
@@ -44,7 +44,7 @@ import utils.ScalazJson4sUtils
 object UserAgentUtilsEnrichmentConfig extends ParseableEnrichment {
 
   val supportedSchema = SchemaCriterion("com.snowplowanalytics.snowplow", "user_agent_utils_config", "jsonschema", 1, 0)
-  private val log             = LoggerFactory.getLogger(getClass())
+  private val log     = LoggerFactory.getLogger(getClass())
 
   // Creates a UserAgentUtilsEnrichment instance from a JValue
   def parse(config: JValue, schemaKey: SchemaKey): ValidatedNelMessage[UserAgentUtilsEnrichment.type] = {

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/enrichments.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/common/enrichments/registry/enrichments.scala
@@ -23,9 +23,6 @@ import java.net.URI
 import scalaz._
 import Scalaz._
 
-// Maven Artifact
-import org.apache.maven.artifact.versioning.DefaultArtifactVersion
-
 // json4s
 import org.json4s.JValue
 

--- a/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/package.scala
+++ b/3-enrich/scala-common-enrich/src/main/scala/com.snowplowanalytics.snowplow.enrich/package.scala
@@ -59,7 +59,7 @@ package object common {
    * keys are enrichment names and
    * whose values are enrichments
    */
-  type EnrichmentMap = Map[String, Enrichment]
+  type EnrichmentMap = Map[String, List[Enrichment]]
 
   /**
    * Type alias for a `ValidationNel`


### PR DESCRIPTION
This is the draft of what I have done so far. Honestly, making this code compile with the changes was not straight-forward. So, I thought it might be better to have everybody's opinions about the code design taken into account from the beginning. 

The change in the nutshell is that we return `List[Enrichment]` instead of `Enrichment` wherever needed.

After the design discussions, I will address the comments and will adjust the unit-tests.  

Please take a look at the changes and tell what do you think.

CC: @Nafid @dmatth