### PR TITLE
[Issue #3753] add options to configure secure, same-site and http-only for the cookie

### DIFF
--- a/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
+++ b/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
@@ -289,11 +289,14 @@ class CollectorService(
     } else {
       cookieConfig.map { config =>
         val responseCookie = HttpCookie(
-          name    = config.name,
-          value   = networkUserId,
-          expires = Some(DateTime.now + config.expiration.toMillis),
-          domain  = config.domain,
-          path    = Some("/")
+          name      = config.name,
+          value     = networkUserId,
+          expires   = Some(DateTime.now + config.expiration.toMillis),
+          domain    = config.domain,
+          path      = Some("/"),
+          secure    = config.secure,
+          httpOnly  = config.httpOnly,
+          extension = config.sameSite.map(value => s"SameSite=$value")
         )
         `Set-Cookie`(responseCookie)
       }

--- a/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
+++ b/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
@@ -49,7 +49,10 @@ package model {
     enabled: Boolean,
     name: String,
     expiration: FiniteDuration,
-    domain: Option[String]
+    domain: Option[String],
+    secure: Boolean,
+    httpOnly: Boolean,
+    sameSite: Option[String]
   )
   final case class DoNotTrackCookieConfig(
     enabled: Boolean,

--- a/2-collectors/scala-stream-collector/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/TestUtils.scala
+++ b/2-collectors/scala-stream-collector/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/TestUtils.scala
@@ -24,7 +24,7 @@ object TestUtils {
     port = 8080,
     p3p = P3PConfig("/w3c/p3p.xml", "NOI DSP COR NID PSA OUR IND COM NAV STA"),
     CrossDomainConfig(enabled = true, List("*"), secure = false),
-    cookie = CookieConfig(true, "sp", 365.days, None),
+    cookie = CookieConfig(true, "sp", 365.days, None, secure = false, httpOnly = false, sameSite = None),
     doNotTrackCookie = DoNotTrackCookieConfig(false, "abc", "123"),
     cookieBounce = CookieBounceConfig(false, "bounce", "new-nuid", None),
     redirectMacro = RedirectMacroConfig(false, None),

--- a/2-collectors/scala-stream-collector/examples/config.hocon.sample
+++ b/2-collectors/scala-stream-collector/examples/config.hocon.sample
@@ -59,6 +59,17 @@ collector {
     # the collector's full domain
     domain = "{{cookieDomain}}"
     domain = ${?COLLECTOR_COOKIE_DOMAIN}
+    secure = false
+    secure = ${?COLLECTOR_COOKIE_SECURE}
+    httpOnly = false
+    httpOnly = ${?COLLECTOR_COOKIE_HTTP_ONLY}
+    # The sameSite is optional. You can choose to not specify the attribute, or you can use `Strict`,
+    # `Lax` or `None` to limit the cookie sent context.
+    #   Strict: the cookie will only be sent along with "same-site" requests.
+    #   Lax: the cookie will be sent with same-site requests, and with cross-site top-level navigation.
+    #   None: the cookie will be sent with same-site and cross-site requests.
+    sameSite = "{{cookieSameSite}}"
+    sameSite = ${?COLLECTOR_COOKIE_SAME_SITE}
   }
 
   # If you have a do not track cookie in place, the Scala Stream Collector can respect it by


### PR DESCRIPTION
This PR address issue #3753. This covers topics related to `ITP 2.1`. More information about cookie access control could be find in the links bellow:
- https://discourse.snowplowanalytics.com/t/itp2-1-and-its-effect-for-snowplow-users/2746/2
- https://web.dev/samesite-cookies-explained/
- https://blog.chromium.org/2019/05/improving-privacy-and-security-on-web.html