### PR TITLE
Stream Enrich: add the possibility to override the DynamoDB endpoint (closes #3942)

### DIFF
--- a/3-enrich/stream-enrich/core/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/Amodel.scala
+++ b/3-enrich/stream-enrich/core/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/Amodel.scala
@@ -49,7 +49,9 @@ object model {
     initialPosition: String,
     initialTimestamp: Option[String],
     backoffPolicy: KinesisBackoffPolicyConfig,
-    customEndpoint: Option[String]
+    customEndpoint: Option[String],
+    dynamodbCustomEndpoint: Option[String],
+    disableCloudWatch: Option[Boolean]
   ) extends SourceSinkConfig {
     val timestamp = initialTimestamp
       .toRight("An initial timestamp needs to be provided when choosing AT_TIMESTAMP")
@@ -64,6 +66,12 @@ object model {
       case cn @ "cn-north-1" => s"https://kinesis.$cn.amazonaws.com.cn"
       case _                 => s"https://kinesis.$region.amazonaws.com"
     })
+
+    val dynamodbEndpoint = dynamodbCustomEndpoint.getOrElse(region match {
+      case cn @ "cn-north-1" => s"https://dynamodb.$cn.amazonaws.com.cn"
+      case _                 => s"https://dynamodb.$region.amazonaws.com"
+    })
+
   }
   final case class Kafka(
     brokers: String,

--- a/3-enrich/stream-enrich/examples/config.hocon.sample
+++ b/3-enrich/stream-enrich/examples/config.hocon.sample
@@ -69,6 +69,13 @@ enrich {
       # customEndpoint = {{kinesisEndpoint}}
       # customEndpoint = ${?ENRICH_STREAMS_SOURCE_SINK_CUSTOM_ENDPOINT}
 
+      ## Optional endpoint url configuration to override aws dyanomdb endpoints for Kinesis checkpoints lease table,
+      ## this can be used to specify local endpoints when using Localstack
+      # dynamodbCustomEndpoint = "http://localhost:4569"
+
+      # Optional override to disable cloudwatch
+      # disableCloudWatch = true
+
       # AWS credentials
       # If both are set to 'default', use the default AWS credentials provider chain.
       # If both are set to 'iam', use AWS IAM Roles to provision credentials.


### PR DESCRIPTION
- We have added the optional endpoint to Dynamodb to make it work with Localstack.
- Also, Cloudwatch metrics was not behaving as expected with Localstack so we needed to use the NullFactory to disable it. 

<!--
Thank you for contributing to Snowplow!

You'll find a small checklist below which should help speed up the review processs:

- [ ] Have you signed the [contributor license agreement](https://github.com/snowplow/snowplow/wiki/CLA)?
- [ ] Have you read the [contributing guide](https://github.com/snowplow/snowplow/blob/master/CONTRIBUTING.md)?
- [ ] Have you added the appropriate unit tests?
- [ ] Have you run the tests through `sbt test`?
- [ ] Is your pull request against the `master` branch?
-->

