### PR TITLE
Scala Stream Collector: allow disabling redirects (fixes #4211)

### DIFF
--- a/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRoute.scala
+++ b/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRoute.scala
@@ -33,7 +33,15 @@ trait CollectorRoute {
   def extractContentType: Directive1[ContentType] =
     extractRequestContext.map(_.request.entity.contentType)
 
-  def collectorRoute: Route =
+  def collectorRoute =
+    if (collectorService.allowRedirects) routes else rejectRedirect ~ routes
+
+  def rejectRedirect: Route =
+    path("r" / Segment) { _ =>
+      complete(StatusCodes.NotFound -> "redirects disabled")
+    }
+
+  def routes: Route =
     doNotTrack(collectorService.doNotTrackCookie) { dnt =>
       cookieIfWanted(collectorService.cookieName) { reqCookie =>
         val cookie = reqCookie.map(_.toCookie)

--- a/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
+++ b/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
@@ -58,6 +58,7 @@ trait Service {
   def cookieName: Option[String]
   def doNotTrackCookie: Option[DntCookieMatcher]
   def determinePath(vendor: String, version: String): String
+  def allowRedirects: Boolean
 }
 
 object CollectorService {
@@ -78,6 +79,7 @@ class CollectorService(
 
   override val cookieName = config.cookieName
   override val doNotTrackCookie = config.doNotTrackHttpCookie
+  override val allowRedirects = config.allowRedirects
 
   /**
    * Determines the path to be used in the response,
@@ -106,7 +108,7 @@ class CollectorService(
 
     val (ipAddress, partitionKey) = ipAndPartitionKey(ip, config.streams.useIpAddressAsPartitionKey)
 
-    val redirect = path.startsWith("/r/")
+    val redirect = config.allowRedirects && path.startsWith("/r/")
 
     val nuidOpt = networkUserId(request, cookie)
     val bouncing = queryParams.get(config.cookieBounce.name).isDefined

--- a/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
+++ b/2-collectors/scala-stream-collector/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
@@ -140,7 +140,8 @@ package model {
     rootResponse: RootResponseConfig,
     cors: CORSConfig,
     streams: StreamsConfig,
-    prometheusMetrics: PrometheusMetricsConfig
+    prometheusMetrics: PrometheusMetricsConfig,
+    allowRedirects: Boolean = true
   ) {
     val cookieConfig = if (cookie.enabled) Some(cookie) else None
     val doNotTrackHttpCookie =

--- a/2-collectors/scala-stream-collector/examples/config.hocon.sample
+++ b/2-collectors/scala-stream-collector/examples/config.hocon.sample
@@ -141,6 +141,11 @@ collector {
     forwardedProtocolHeader = ${?COLLECTOR_COOKIE_BOUNCE_FORWARDED_PROTOCOL_HEADER}
   }
 
+  # When enabled, redirect prefix `r/` will be enabled and its query parameters resolved.
+  # Otherwise the request prefixed with `r/` will be dropped with `404 Not Found`
+  allowRedirects = false
+  allowRedirects = ${?COLLECTOR_ALLOW_REDIRECTS}
+
   # When enabled, the redirect url passed via the `u` query parameter is scanned for a placeholder
   # token. All instances of that token are replaced withe the network ID. If the placeholder isn't
   # specified, the default value is `${SP_NUID}`.


### PR DESCRIPTION
Add a new flag `collector.allowRedirects` that when set to false will prohibit (`410 Gone`) any redirects using `r/` prefix url.

Not adding `Bump to version`. This probably should come with the same version as the #4204.

<!--
Thank you for contributing to Snowplow!

You'll find a small checklist below which should help speed up the review processs:

- [ ] Have you signed the [contributor license agreement](https://github.com/snowplow/snowplow/wiki/CLA)?
- [ ] Have you read the [contributing guide](https://github.com/snowplow/snowplow/blob/master/CONTRIBUTING.md)?
- [ ] Have you added the appropriate unit tests?
- [ ] Have you run the tests through `sbt test`?
- [ ] Is your pull request against the `master` branch?
-->

