### PR TITLE
Update build.sbt

### DIFF
--- a/2-collectors/scala-stream-collector/build.sbt
+++ b/2-collectors/scala-stream-collector/build.sbt
@@ -110,4 +110,6 @@ lazy val nsq = project
 lazy val stdout = project
   .settings(moduleName := "snowplow-stream-collector-stdout")
   .settings(allSettings)
+  .settings(packageName in Docker := "snowplow/scala-stream-collector-stdout")
+  .enablePlugins(JavaAppPackaging, DockerPlugin)
   .dependsOn(core)


### PR DESCRIPTION
scala-stream-collector: added docker plugin for stdout module. This now will go with the documentation - https://github.com/snowplow/snowplow/wiki/Run-the-Scala-Stream-Collector to run the jar using stdout as the target.

<!--
Thank you for contributing to Snowplow!

You'll find a small checklist below which should help speed up the review process:

- [x] Have you signed the [contributor license agreement](https://github.com/snowplow/snowplow/wiki/CLA)?
- [x] Have you read the [contributing guide](https://github.com/snowplow/snowplow/blob/master/CONTRIBUTING.md)?
- [ ] Have you added the appropriate unit tests? NOT NEEDED
- [x] Have you run the tests through `sbt test`? - YES
- [x] Is your pull request against the `master` branch?
-->

