### PR TITLE
Update config.hocon.sample

### DIFF
--- a/2-collectors/scala-stream-collector/examples/config.hocon.sample
+++ b/2-collectors/scala-stream-collector/examples/config.hocon.sample
@@ -277,10 +277,9 @@ collector {
       # The kafka producer has a variety of possible configuration options defined at
       # https://kafka.apache.org/documentation/#producerconfigs
       # Some values are set to other values from this config by default:
-      # "bootstrap.servers" -> brokers
-      # retries             -> retries
-      # "buffer.memory"     -> buffer.byteLimit
-      # "linger.ms"         -> buffer.timeLimit
+      # "bootstrap.servers" = brokers
+      # "buffer.memory"     = buffer.byteLimit
+      # "linger.ms"         = buffer.timeLimit
       #producerConf {
       #  acks = all
       #  "key.serializer"     = "org.apache.kafka.common.serialization.StringSerializer"


### PR DESCRIPTION
1) Replacing the '->' symbol with '=' , as if we uncomment the settings will result in a runnable error.
Error Details -
[error] (run-main-0) com.typesafe.config.ConfigException$Parse: /home/piyush/Desktop/myconf.conf: 281: Key 'bootstrap.servers -> brokers' may not be followed by token: 'retries' (if you intended 'retries' to be part of a key or string value, try enclosing the key or value in double quotes)
[error] com.typesafe.config.ConfigException$Parse: /home/piyush/Desktop/myconf.conf: 281: Key 'bootstrap.servers -> brokers' may not be followed by token: 'retries' (if you intended 'retries' to be part of a key or string value, try enclosing the key or value in double quotes)

2) Removing the duplicate setting       # retries             = retries, as its been defined and placed with the default value.
Also if once uncommented results in parsing error.

<!--
Thank you for contributing to Snowplow!

You'll find a small checklist below which should help speed up the review processs:

- [x] Have you signed the [contributor license agreement](https://github.com/snowplow/snowplow/wiki/CLA)?
- [x] Have you read the [contributing guide](https://github.com/snowplow/snowplow/blob/master/CONTRIBUTING.md)?
- [x] Have you added the appropriate unit tests? - Not Needed
- [x] Have you run the tests through `sbt test`?
- [x] Is your pull request against the `master` branch?
-->

