### PR TITLE
Oidc

### DIFF
--- a/2-collectors/scala-stream-collector/build.sbt
+++ b/2-collectors/scala-stream-collector/build.sbt
@@ -79,7 +79,10 @@ lazy val kinesis = project
   .settings(moduleName := "snowplow-stream-collector-kinesis")
   .settings(allSettings)
   .settings(packageName in Docker := "snowplow/scala-stream-collector-kinesis")
-  .settings(libraryDependencies ++= Seq(Dependencies.Libraries.kinesis, Dependencies.Libraries.cbor))
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.Libraries.kinesis, 
+    Dependencies.Libraries.sts, 
+    Dependencies.Libraries.cbor))
   .enablePlugins(JavaAppPackaging, DockerPlugin)
   .dependsOn(core)
 

--- a/2-collectors/scala-stream-collector/examples/config.hocon.sample
+++ b/2-collectors/scala-stream-collector/examples/config.hocon.sample
@@ -243,7 +243,10 @@ collector {
       # If both are set to 'default', the default provider chain is used
       # (see http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html)
       # If both are set to 'iam', use AWS IAM Roles to provision credentials.
-      # If both are set to 'env', use environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+      # If both are set to 'env', use environment variables AWS_ACCESS_KEY_ID and 
+      # if both are set to 'oidc', use aws OIDC credentials (for running in EKS cluster with a K8S ServiceAccount with IAM Role - see https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html )
+
+      AWS_SECRET_ACCESS_KEY
       aws {
         accessKey = iam
         accessKey = ${?COLLECTOR_STREAMS_SINK_AWS_ACCESS_KEY}

--- a/2-collectors/scala-stream-collector/kinesis/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/KinesisSink.scala
+++ b/2-collectors/scala-stream-collector/kinesis/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/KinesisSink.scala
@@ -75,6 +75,7 @@ object KinesisSink {
     def isDefault(key: String): Boolean = key == "default"
     def isIam(key: String): Boolean = key == "iam"
     def isEnv(key: String): Boolean = key == "env"
+    def isOIDC(key: String): Boolean = key == "oidc"
 
     ((awsConfig.accessKey, awsConfig.secretKey) match {
       case (a, s) if isDefault(a) && isDefault(s) =>
@@ -89,6 +90,10 @@ object KinesisSink {
         new EnvironmentVariableCredentialsProvider().asRight
       case (a, s) if isEnv(a) || isEnv(s) =>
         "accessKey and secretKey must both be set to 'env' or neither".asLeft
+      case (a, s) if isOIDC(a) && isOIDC(s) =>
+        new WebIdentityTokenCredentialsProvider().asRight
+      case (a, s) if isOIDC(a) || isOIDC(s) =>
+        "accessKey and secretKey must both be set to 'oicd' or neither".asLeft
       case _ =>
         new AWSStaticCredentialsProvider(
           new BasicAWSCredentials(awsConfig.accessKey, awsConfig.secretKey)

--- a/2-collectors/scala-stream-collector/project/Dependencies.scala
+++ b/2-collectors/scala-stream-collector/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
 
   object V {
     // Java
-    val awsSdk               = "1.11.573"
+    val awsSdk               = "1.11.797"
     val pubsub               = "1.78.0"
     val kafka                = "2.2.1"
     val nsqClient            = "1.2.0"
@@ -51,6 +51,7 @@ object Dependencies {
   object Libraries {
     // Java
     val kinesis              = "com.amazonaws"                    %  "aws-java-sdk-kinesis"   % V.awsSdk
+    val sts                  = "com.amazonaws"                    %  "aws-java-sdk-sts"       % V.awsSdk
     val pubsub               = "com.google.cloud"                 %  "google-cloud-pubsub"    % V.pubsub
     val kafkaClients         = "org.apache.kafka"                 %  "kafka-clients"          % V.kafka
     val nsqClient            = "com.snowplowanalytics"            %  "nsq-java-client"        % V.nsqClient

--- a/3-enrich/stream-enrich/build.sbt
+++ b/3-enrich/stream-enrich/build.sbt
@@ -77,6 +77,7 @@ lazy val kinesis = project
   .settings(BuildSettings.formatting)
   .settings(libraryDependencies ++= Seq(
     Dependencies.Libraries.kinesisClient,
+    Dependencies.Libraries.sts,
     Dependencies.Libraries.kinesisSdk,
     Dependencies.Libraries.dynamodbSdk,
     Dependencies.Libraries.jacksonCbor

--- a/3-enrich/stream-enrich/core/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/utils.scala
+++ b/3-enrich/stream-enrich/core/src/main/scala/com.snowplowanalytics.snowplow.enrich.stream/utils.scala
@@ -33,7 +33,8 @@ import com.amazonaws.auth.{
   BasicAWSCredentials,
   DefaultAWSCredentialsProviderChain,
   EnvironmentVariableCredentialsProvider,
-  InstanceProfileCredentialsProvider
+  InstanceProfileCredentialsProvider,
+  WebIdentityTokenCredentialsProvider
 }
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.s3.model.GetObjectRequest
@@ -75,6 +76,7 @@ object utils {
     def isDefault(key: String): Boolean = key == "default"
     def isIam(key: String): Boolean = key == "iam"
     def isEnv(key: String): Boolean = key == "env"
+    def isOIDC(key: String): Boolean = key == "oidc"
 
     for {
       provider <- creds match {
@@ -92,6 +94,10 @@ object utils {
           new EnvironmentVariableCredentialsProvider().asRight
         case AWSCredentials(a, s) if isEnv(a) || isEnv(s) =>
           "accessKey and secretKey must both be set to 'env' or neither".asLeft
+        case AWSCredentials(a, s) if isOIDC(a) && isOIDC(s) =>
+          new WebIdentityTokenCredentialsProvider().asRight
+        case AWSCredentials(a, s) if isOIDC(a) || isOIDC(s) =>
+          "accessKey and secretKey must both be set to 'oicd' or neither".asLeft
         case AWSCredentials(a, s) =>
           new AWSStaticCredentialsProvider(new BasicAWSCredentials(a, s)).asRight
       }

--- a/3-enrich/stream-enrich/examples/config.hocon.sample
+++ b/3-enrich/stream-enrich/examples/config.hocon.sample
@@ -82,6 +82,7 @@ enrich {
       # If both are set to 'default', use the default AWS credentials provider chain.
       # If both are set to 'iam', use AWS IAM Roles to provision credentials.
       # If both are set to 'env', use env variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+      # if both are set to 'oidc', use aws OIDC credentials (for running in EKS cluster with a K8S ServiceAccount with IAM Role - see https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html )      
       # aws {
       #   accessKey = iam
       #   accessKey = ${?ENRICH_STREAMS_SOURCE_SINK_AWS_ACCESS_KEY}

--- a/3-enrich/stream-enrich/project/Dependencies.scala
+++ b/3-enrich/stream-enrich/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Dependencies {
 
   object V {
     // Java
-    val awsSdk               = "1.11.566"
+    val awsSdk               = "1.11.797"
     val kinesisClient        = "1.10.0"
     val kafka                = "2.2.1"
     val nsqClient            = "1.2.0"
@@ -54,6 +54,7 @@ object Dependencies {
     val dynamodbSdk          = "com.amazonaws"                    %  "aws-java-sdk-dynamodb"     % V.awsSdk
     val s3Sdk                = "com.amazonaws"                    %  "aws-java-sdk-s3"           % V.awsSdk
     val kinesisClient        = "com.amazonaws"                    %  "amazon-kinesis-client"     % V.kinesisClient
+    val sts                  = "com.amazonaws"                    %  "aws-java-sdk-sts"          % V.awsSdk
     val kafkaClients         = "org.apache.kafka"                 %  "kafka-clients"             % V.kafka
     val nsqClient            = "com.snowplowanalytics"            %  "nsq-java-client"           % V.nsqClient
     val jacksonCbor          = "com.fasterxml.jackson.dataformat" %  "jackson-dataformat-cbor"   % V.jackson


### PR DESCRIPTION
This PR adds support for using the OIDC based authentication to 
* scala-stream-collector/kinesis
* stream-enrich/kinesis
This is used with running the containers in an EKS cluster with IAM roles associated to K8S Service accounts (see https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)

To enable the accessKey and secretKey should be set to `oidc`
```
    aws {
      accessKey = "oidc"
      secretKey = "oidc"
    }
```
