### PR TITLE
Remove specific rdb-loader tag pattern for auto-updates

### DIFF
--- a/.scripts/lib.sh
+++ b/.scripts/lib.sh
@@ -46,10 +46,6 @@ function is_release_tag() (
             tag_pattern='v+([0-9]).+([0-9]).+([0-9])'
             [[ "${__tag}" = $tag_pattern ]] && echo "${__tag#v}" || return 1
             ;;
-        4-storage/snowplow-rdb-loader)
-            tag_pattern='r+([0-9])'
-            [[ "${__tag}" = $tag_pattern ]] && echo "${__tag}" || return 1
-            ;;
         5-data-modeling/data-models)
             tag_pattern='**/+([0-9]).+([0-9]).+([0-9])'
             [[ "${__tag}" = $tag_pattern ]] && echo "${__tag}" || return 1


### PR DESCRIPTION
It will now expect to match the common case `tag_pattern='+([0-9]).+([0-9]).+([0-9])'`