### PR TITLE
Add github actions workflow for hotfix updating a submodule

### DIFF
--- a/.github/workflows/submodule_hotfix.yml
+++ b/.github/workflows/submodule_hotfix.yml
@@ -1,0 +1,68 @@
+name: submodule_update_hotfix
+
+on:
+  workflow_dispatch:
+    inputs:
+      submodule_name:
+        description: 'Submodule name as specified in gitmodules'
+        required: true
+      commit_message:
+        description: 'The commit message to be used on submodule update'
+        required: true
+      do_retagging:
+        description: 'Whether to delete and retag, only yes confirms'
+        required: true
+        default: no
+      tag_name:
+        description: 'The tag name to re-tag if necessary'
+        required: false
+      snowplow_commit_sha1:
+        description: 'The commit in current repository the tag refers to'
+        required: false
+
+jobs:
+  submodule_update_hotfix:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Check input for retagging
+      if: ${{ github.event.inputs.do_retagging == 'yes' }}
+      run: |
+        if [ -z "${{ github.event.inputs.tag_name }}" ] ; then
+            echo "${INPUT_ERR_MSG}"
+            exit 1
+        fi
+        if [ -z "${{ github.event.inputs.snowplow_commit_sha1 }}" ] ; then
+            echo "${INPUT_ERR_MSG}"
+            exit 1
+        fi
+      env:
+        INPUT_ERR_MSG: 'ERROR: For retagging both tag_name and snowplow_commit_sha1 need to be provided.'
+
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: master
+        submodules: true
+        token: ${{ github.token }}
+
+    - name: Set github-actions name and email
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+    - name: Update submodule and retag accordingly
+      run: |
+        .scripts/hotfix.sh \
+            "${{ github.event.inputs.submodule_name }}" \
+            "${{ github.event.inputs.commit_message }}" \
+            "${{ github.event.inputs.do_retagging }}" \
+            "${{ github.event.inputs.tag_name }}" \
+            "${{ github.event.inputs.snowplow_commit_sha1 }}"
+
+    - name: Push tags and commits to master
+      run: |
+        git push --tags --verbose
+        git push origin master --verbose

--- a/.scripts/hotfix.sh
+++ b/.scripts/hotfix.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) 2021 Snowplow Analytics Ltd. All rights reserved.
+#
+# This program is licensed to you under the Apache License Version 2.0,
+# and you may not use this file except in compliance with the Apache License Version 2.0.
+# You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the Apache License Version 2.0 is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+#
+
+
+set -e
+
+#
+# USAGE: ./commit_retag.sh $submod_name $commit_msg $do_retag $tag_name $prev_sha
+# - the submodule name
+# - the commit message for update
+# - flag, whether to do retagging (i.e. delete tag and retag on the update commit)
+# - the tag name to be deleted and used to retag the update commit
+# - the superproject commit that the tag referred to previously (for sanity check)
+#
+# Assumes tag_name and prev_sha are non empty.
+#
+
+REPO_REMOTE='origin'
+
+# -----------------------------------------------------------------------------
+#  FUNCTIONS & PROCEDURES
+# -----------------------------------------------------------------------------
+. ${0%/*}/lib.sh
+
+# Given a submodule name and a commit message,
+#  - updates the submodule to its **latest** commit (default branch)
+#  - and commits onto the superproject using the given commit message
+# Fails if:
+#  - no submodule path was found for given name
+#  - no changes after update (submodule already on latest)
+function commit_update() {
+    [ "$#" -eq 2 ] || die "2 arguments required, $# provided to 'func:commit_update'"
+    local __mod_name="$1"
+    local __commit_msg="$2"
+
+    submodule_path=`git submodule--helper config submodule."${__mod_name}".path`
+    [ -z "${submodule_path}" ] && die "Exiting: Submodule path not found for ${__mod_name}"
+
+    git submodule update --remote --checkout "${__mod_name}"
+    [[ -z `git status -s` ]] && die 'Exiting: No unstaged changes found!'
+
+    git add "${submodule_path}"
+    git commit -m "${__commit_msg}"
+}
+
+# Given a tag and a commit hash,
+#  - deletes the tag remotely and locally
+# Fails if:
+#  - the tag does not exist
+#  - the tag does not reference the given commit
+function delete_tag() {
+    [ "$#" -eq 2 ] || die "2 arguments required, $# provided to 'func:delete_tag'"
+    local __tag_name="$1"
+    local __commit_sha="$2"
+
+    if tag_ref=`git rev-parse --quiet --verify --end-of-options "${__tag_name}"^{commit}` ; then
+        if [ "${tag_ref}" != "${__commit_sha}" ] ; then
+            die "Exiting: Tag ${__tag_name} is not associated to specified commit ${__commit_sha}"
+        fi
+    else
+        die "Exiting: Tag ${__tag_name} not found"
+    fi
+
+    echo 'Tag reference ok.'
+    echo 'Deleting remote tag..'
+    git push --delete "${REPO_REMOTE}" "${__tag_name}"
+    echo 'Deleting local tag..'
+    git tag --delete "${__tag_name}"
+}
+
+# -----------------------------------------------------------------------------
+#  ARGUMENT PARSING
+# -----------------------------------------------------------------------------
+[ "$#" -eq 5 ] || die "5 arguments required, $# provided to 'script:hotfix'"
+submod_name="$1"
+commit_msg="$2"
+do_retag="$3"
+tag_name="$4"
+prev_sha="$5"
+
+# -----------------------------------------------------------------------------
+#  COMMANDS
+# -----------------------------------------------------------------------------
+
+# Update the submodule and commit changes
+commit_update "${submod_name}" "${commit_msg}"
+
+echo 'LOG: git-show'
+git show --format=raw HEAD^..HEAD
+
+# do_retag flag set to yes, first delete and then tag the latest local commit
+if [ "${do_retag}" = 'yes' ]; then
+    delete_tag "${tag_name}" "${prev_sha}"
+    echo 'Tagging latest commit..'
+    git tag -a "${tag_name}" -m "${tag_name}"
+fi


### PR DESCRIPTION
There are some rare cases that the scheduled `submodules_update` Github Action workflow cannot handle and/or where manual intervention is inevitable or desired. For example:

- update a submodule to its latest (but non-release) commit (e.g. Readme after-release fixes)
- update a submodule to its latest commit where retagging is also necessary (i.e. move a tag to another commit in superproject), which, however, the main `submodules_update` workflow cannot handle.

This PR introduces a new workflow that only runs-on workflow dispatch (can only be triggered manually), in order to both replace and document those manual steps, where an update of a particular submodule is involved.

Can be seen in action on this temporary [test fork](https://github.com/adatzer/snowplow-tmp-1). The workflow runs can be seen [here](https://github.com/adatzer/snowplow-tmp-1/actions). All failing runs were expected, to show the cases where the script "should" fail.

Under the hood the script uses `git submodule update`, which was what was run manually for this [PR](https://github.com/snowplow/snowplow/pull/4519) (which could be closed in favor of this one).
