### PR TITLE
Remove usage of git submodule--helper (close #4559)

### DIFF
--- a/.scripts/hotfix.sh
+++ b/.scripts/hotfix.sh
@@ -45,7 +45,7 @@ function commit_update() {
     local __mod_name="$1"
     local __commit_msg="$2"
 
-    submodule_path=`git submodule--helper config submodule."${__mod_name}".path`
+    submodule_path=`git config -f .gitmodules submodule."${__mod_name}".path`
     [ -z "${submodule_path}" ] && die "Exiting: Submodule path not found for ${__mod_name}"
 
     git submodule update --remote --checkout "${__mod_name}"

--- a/.scripts/lib.sh
+++ b/.scripts/lib.sh
@@ -77,7 +77,7 @@ function merge_bump() {
     cd "${__top_level}"
 
     # 3. get repo name for commit message
-    repo_url=`git submodule--helper config submodule."${__mod_name}".url`
+    repo_url=`git config -f .gitmodules submodule."${__mod_name}".url`
     [ -z "${repo_url}" ] && die "Submodule url not found for ${__mod_name}"
     repo_name=`basename "${repo_url}" .git`
     commit_msg="${repo_name}: Release ${__bump_tag}"


### PR DESCRIPTION
We use an internal function of `git submodule--helper` which has been removed in recent versions of git and no longer works on Github Actions.

We should be able to switch to `git config -f .gitmodules` as a public API alternative.

https://github.com/git/git/commit/cc74a4ac7255510b4a928d4973dcfcc746d74e8f