### PR TITLE
Fix submodule checkout in hotfix script

### DIFF
--- a/.scripts/hotfix.sh
+++ b/.scripts/hotfix.sh
@@ -48,7 +48,7 @@ function commit_update() {
     submodule_path=`git config -f .gitmodules submodule."${__mod_name}".path`
     [ -z "${submodule_path}" ] && die "Exiting: Submodule path not found for ${__mod_name}"
 
-    git submodule update --remote --checkout "${__mod_name}"
+    git submodule update --remote --checkout "${submodule_path}"
     [[ -z `git status -s` ]] && die 'Exiting: No unstaged changes found!'
 
     git add "${submodule_path}"


### PR DESCRIPTION
There is a bug in the hotfix script, which uses the submodule name instead of the submodule pathspec when checking out:

https://github.com/snowplow/snowplow/blob/4796ccab1068f4cccce8ed2dfa7c65376c18536d/.scripts/hotfix.sh#L51

This happens to work when the name is the same as the pathspec, which is the case for many of the submodules in this repository, but only by accident. 

[Link to documentation](https://git-scm.com/docs/git-submodule#Documentation/git-submodule.txt-update--init--remote-N--no-fetch--no-recommend-shallow-f--force--checkout--rebase--merge--referenceltrepositorygt--ref-formatltformatgt--depthltdepthgt--recursive--jobsltngt--no-single-branch--filterltfilter-specgt--ltpathgt82308203)